### PR TITLE
Restore target temperatures and preset modes on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,19 +81,25 @@ _default: Dual Smart_
 
 ### target_temp
 
-  _(optional) (float)_ Set initial target temperature. Failure to set this variable will result in target temperature being set to null on startup.
+  _(optional) (float)_ Set initial target temperature. If this variable is not set, it will retain the target temperature set before restart if available.
 
 ### target_temp_low
 
-  _(optional) (float)_ Set initial target low temperature. Failure to set this variable will result in target temperature being set to null on startup.
+  _(optional) (float)_ Set initial target low temperature. If this variable is not set, it will retain the target temperature low set before restart if available.
 
 ### target_temp_high
 
-  _(optional) (float)_ Set initial target high temperature. Failure to set this variable will result in target temperature being set to null on startup.
+  _(optional) (float)_ Set initial target high temperature. If this variable is not set, it will retain the target temperature high set before restart if available.
 
 ### ac_mode
 
-  _(optional) (boolean)_ Set the switch specified in the *heater* option to be treated as a cooling device instead of a heating device.
+  _(optional) (boolean)_ Set the switch specified in the `heater` option to be treated as a cooling device instead of a heating device. This parameter will be ignored if `cooler` option is defined.
+
+  _default: false_
+
+### heat_cool_mode
+
+  _(optional) (boolean)_ If variable `target_temp_low` and `target_temp_high` are not set, this parameter must be set to *true* to enable the `heat_cool` mode.
 
   _default: false_
 
@@ -125,29 +131,35 @@ _default: Dual Smart_
 
 ### away_temp
 
-  _(optional) (float)_ "Set the temperature used by `preset_mode: away`. If this is not specified, the preset mode feature will not be available."
+  _(optional) (float)_ "Set the temperature used by `preset_mode: away`. If this is not specified, the preset mode feature will not be available. N.B. Presets are not available for `heat_cool` mode."
 
 ### eco_temp
 
-  _(optional) (float)_ "Set the temperature used by `preset_mode: eco`. If this is not specified, the preset mode feature will not be available."
+  _(optional) (float)_ "Set the temperature used by `preset_mode: eco`. If this is not specified, the preset mode feature will not be available. N.B. Presets are not available for `heat_cool` mode."
 
-### at_home_temp
+### home_temp
 
-  _(optional) (float)_ "Set the temperature used by `preset_mode: home`. If this is not specified, the preset mode feature will not be available."
+  _(optional) (float)_ "Set the temperature used by `preset_mode: home`. If this is not specified, the preset mode feature will not be available. N.B. Presets are not available for `heat_cool` mode."
 
 ### comfort_temp
 
-  _(optional) (float)_ "Set the temperature used by `preset_mode: comfort`. If this is not specified, the preset mode feature will not be available."
+  _(optional) (float)_ "Set the temperature used by `preset_mode: comfort`. If this is not specified, the preset mode feature will not be available. N.B. Presets are not available for `heat_cool` mode."
 
 ### anti_freeze_temp
 
-  _(optional) (float)_ "Set the temperature used by `preset_mode: anti freeze`. If this is not specified, the preset mode feature will not be available."
+  _(optional) (float)_ "Set the temperature used by `preset_mode: anti freeze`. If this is not specified, the preset mode feature will not be available. N.B. Presets are not available for `heat_cool` mode."
 
 ### precision
 
-  _(optional) (float)_ "The desired precision for this device. Can be used to match your actual thermostat's precision. Supported values are `0.1`, `0.5` and `1.0`."
+  _(optional) (float)_ The desired precision for this device. Can be used to match your actual thermostat's precision. Supported values are `0.1`, `0.5` and `1.0`.
 
-  _default: "`0.5` for Celsius and `1.0` for Fahrenheit."_
+  _default: `0.5` for Celsius and `1.0` for Fahrenheit._
+
+### target_temp_step 
+
+  _(optional) (float)_ The desired step size for setting the target temperature. Supported values are `0.1`, `0.5` and `1.0`.
+
+  _default: Value used for `precision`_
 
 ## Installation
 

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -396,7 +396,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
                             self._target_temp_low,
                         )
                     else:
-                        self._target_temp_low = old_target_min
+                        self._target_temp_low = float(old_target_min)
                 if self._target_temp_high is None:
                     old_target_max = old_state.attributes.get(ATTR_TARGET_TEMP_HIGH)
                     if old_target_max is None:
@@ -406,13 +406,14 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
                             self._target_temp_high,
                         )
                     else:
-                        self._target_temp_high = old_target_max
+                        self._target_temp_high = float(old_target_max)
             else:
                 if hvac_mode not in self.hvac_modes:
                     hvac_mode = HVACMode.OFF
                 if self._target_temp is None:
                     # If we have a previously saved temperature
-                    if old_state.attributes.get(ATTR_TEMPERATURE) is None:
+                    old_target = old_state.attributes.get(ATTR_TEMPERATURE)
+                    if old_target is None:
                         if self.ac_mode:
                             self._target_temp = self.max_temp
                         else:
@@ -422,7 +423,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
                             self._target_temp,
                         )
                     else:
-                        self._target_temp = float(old_state.attributes[ATTR_TEMPERATURE])
+                        self._target_temp = float(old_target)
                         old_pres_mode = old_state.attributes.get(ATTR_PRESET_MODE)
                         if self.preset_modes and old_pres_mode in self.preset_modes:
                             self._preset_mode = old_pres_mode

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -412,6 +412,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
                     hvac_mode = HVACMode.OFF
                 self._set_default_target_temps()
 
+                # restore previous preset mode if available
                 old_pres_mode = old_state.attributes.get(ATTR_PRESET_MODE)
                 if self.preset_modes and old_pres_mode in self._presets:
                     self._preset_mode = old_pres_mode
@@ -424,6 +425,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
             # No previous state, try and restore defaults
             if not self._hvac_mode:
                 self._hvac_mode = HVACMode.OFF
+            if self._hvac_mode == HVACMode.OFF:
                 self._set_default_target_temps()
 
         # Set correct support flag

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -7,11 +7,11 @@ from typing import List
 
 import voluptuous as vol
 
-from homeassistant.components.climate import (
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
+from homeassistant.components.climate.const import (
     ATTR_PRESET_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    PLATFORM_SCHEMA,
     PRESET_AWAY,
     PRESET_ECO,
     PRESET_COMFORT,
@@ -20,7 +20,6 @@ from homeassistant.components.climate import (
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
-    ClimateEntity,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -424,12 +423,9 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
                         )
                     else:
                         self._target_temp = float(old_state.attributes[ATTR_TEMPERATURE])
-                        if (
-                            self.preset_modes
-                            and old_state.attributes.get(ATTR_PRESET_MODE)
-                            in self.preset_modes
-                        ):
-                            self._preset_mode = old_state.attributes.get(ATTR_PRESET_MODE)
+                        old_pres_mode = old_state.attributes.get(ATTR_PRESET_MODE)
+                        if self.preset_modes and old_pres_mode in self.preset_modes:
+                            self._preset_mode = old_pres_mode
 
             self._hvac_mode = hvac_mode
 

--- a/custom_components/dual_smart_thermostat/const.py
+++ b/custom_components/dual_smart_thermostat/const.py
@@ -1,5 +1,4 @@
 """const"""
-from homeassistant.components.climate import SUPPORT_TARGET_TEMPERATURE
 from homeassistant.backports.enum import StrEnum
 
 
@@ -28,7 +27,6 @@ CONF_TEMP_STEP = "target_temp_step"
 CONF_OPENINGS = "openings"
 CONF_HEAT_COOL_MODE = "heat_cool_mode"
 PRESET_ANTI_FREEZE = "Anti Freeze"
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 
 
 class HVACMode(StrEnum):

--- a/custom_components/dual_smart_thermostat/const.py
+++ b/custom_components/dual_smart_thermostat/const.py
@@ -1,8 +1,5 @@
 """const"""
-from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE,
-)
-
+from homeassistant.components.climate import SUPPORT_TARGET_TEMPERATURE
 from homeassistant.backports.enum import StrEnum
 
 
@@ -26,13 +23,10 @@ CONF_COLD_TOLERANCE = "cold_tolerance"
 CONF_HOT_TOLERANCE = "hot_tolerance"
 CONF_KEEP_ALIVE = "keep_alive"
 CONF_INITIAL_HVAC_MODE = "initial_hvac_mode"
-CONF_AWAY_TEMP = "away_temp"
-CONF_ECO_TEMP = "eco_temp"
-CONF_COMFORT_TEMP = "comfort_temp"
-CONF_AT_HOME_TEMP = "at_home_temp"
-CONF_ANTI_FREEZE_TEMP = "anti_freeze_temp"
 CONF_PRECISION = "precision"
+CONF_TEMP_STEP = "target_temp_step"
 CONF_OPENINGS = "openings"
+CONF_HEAT_COOL_MODE = "heat_cool_mode"
 PRESET_ANTI_FREEZE = "Anti Freeze"
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -226,6 +226,7 @@ async def test_heater_cooler_mode(hass, setup_comp_1):
                 "name": "test",
                 "cooler": cooler_switch,
                 "heater": heater_switch,
+                "heat_cool_mode": True,
                 "target_sensor": temp_input,
                 "initial_hvac_mode": HVACMode.HEAT_COOL,
             }


### PR DESCRIPTION
Sorry for so big CR, I implemented some improvement and bug fix:

1) Implemented restore of previous state for all target temperatures at startup
2) added config options `heat_cool_mode` to enable the mode without setting the min and max target temp
3) review the `preset mode` controls (more simple to add new presets)
4) disabled `preset mode` support when the `heat_cool` mode is selected (this would create issue and conflict with the target temperatures)
5) added  config options `temperature_step` to allow set this (default to `precision` if not set) 
6) fixed an issue that would prevent to disable `cooler` entity when working in `cool` mode
7) improved switching from `SUPPORT_TARGET_TEMPERATURE` to `SUPPORT_TARGET_TEMPERATURE_RANGE` mode 
8) updated `Readme`

This PR should also fix issue #34 

IMHO presets would require additional reworks to also allow to specify the target HVAC Mode and may be also support the `heat_cool` mode. Anyway I'm not sure this would be really useful (I don't use presets at all).

Available for any support during your review.
 