### PR TITLE
feat:  additional attribute or hvac_action_reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@ The `dual_smart_thermostat` is an enhanced version of generic thermostat impleme
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/swingerman/ha-dual-smart-thermostat) ![Release](https://img.shields.io/github/v/release/swingerman/ha-dual-smart-thermostat?style=for-the-badge) [![Donate](https://img.shields.io/badge/Donate-PayPal-yellowgreen?style=for-the-badge&logo=paypal)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=S6NC9BYVDDJMA&source=url)
 
+## Table of contents
+
+- [Features](#features)
+- [Services](#services)
+- [Configuration variables](#configuration-variables)
+- [Installation](#installation)
 
 ## Features
-
 
 |  |  | |
 | :--- | :---: | :---: |
@@ -17,6 +22,7 @@ The `dual_smart_thermostat` is an enhanced version of generic thermostat impleme
 | **Floor Temperature Control** | <img src="docs/images/heating-coil.svg" height="30" /> <img src="docs/images/snowflake-thermometer.svg" height="30" />  <img src="docs/images/thermometer-alert.svg" height="30" />  | [<img src="docs/images/file-document-outline.svg" height="30" />](#floor-heating-temperature-control) |
 | **Window/Door sensor integration** | <img src="docs/images/window-open.svg" height="30" /> <img src="docs/images/door-open.svg" height="30" /> <img src="docs/images/chevron-right.svg" height="30" /> <img src="docs/images/timer-cog-outline.svg" height="30" /> <img src="docs/images/chevron-right.svg" height="30" /> <img src="docs/images/hvac-off.svg" height="30" /> | [<img src="docs/images/file-document-outline.svg" height="30" />](#openings) |
 | **Presets** | <img src="docs/images/sleep.svg" height="30" /> <img src="docs/images/snowflake-thermometer.svg" height="30" /> <img src="docs/images/shield-lock-outline.svg" height="30" /> | [<img src="docs/images/file-document-outline.svg" height="30" />](#presets) |
+| **HVAC Action Reason** | | [<img src="docs/images/file-document-outline.svg" height="30" />](#presets) |
 
 
 ## Heat/Cool Mode
@@ -142,7 +148,55 @@ preset_name:
   target_temp_high: 14
 ```
 
+## HVAC Action Reason
+
+
+State attribute: `hvac_action_reason`
+
+The `dual_smart_thermostat` will set the `hvac_action` attribute to `heating`, `cooling`, `idle` or `off` based on the current state of the thermostat. The `hvac_action` attribute is used to indicate the current action of the thermostat. The `dual_smart_thermostat` will also set the `hvac_action_reason` attribute based on the current state of the thermostat. The `hvac_action_reason` attribute is used to indicate the reason for the current action of the thermostat.
+
+### HVAC Action Reason values
+
+The `hvac_action_reason` attribute is grouped by [internal](#hvac-action-reason-internal-values) and [external](#hvac-action-reason-external-values) values.
+The internal values can be set by the component only and the external values can be set by the user or automations.
+
+#### HVAC Action Reason Internal values
+
+| Value | Description |
+|-------|-------------|
+| `none` | No action reason |
+| `target_temp_not_reached` | The target temperature has not been reached |
+| `target_temp_reached` | The target temperature has been reached |
+| `misconfiguration` | The thermostat is misconfigured |
+| `opening` | The thermostat is idle because an opening is open |
+| `limit` | The thermostat is idle because the floor temperature is at the limit |
+| `overheat` | The thermostat is idle because the floor temperature is too high |
+
+#### HVAC Action Reason External values
+
+| Value | Description |
+|-------|-------------|
+| `none` | No action reason |
+| `presence`| the last HVAc action was triggered by presence |
+| `schedule` | the last HVAc action was triggered by schedule |
+| `emergency` | the last HVAc action was triggered by emergency |
+| `malfunction` | the last HVAc action was triggered by malfunction |
+
+
 [all features ⤴️](#features)
+
+## Services
+
+### Set HVAC Action Reason
+
+`dial_smart_thermostat.set_hvac_action_reason` is exposed for automations to set the `hvac_action_reason` attribute. The service accepts the following parameters:
+
+| Parameter | Description | Type | Required |
+|-----------|-------------|------|----------|
+| entity_id | The entity id of the thermostat | string | yes |
+| hvac_action_reason | The reason for the current action of the thermostat | [HVACActionReasonExternal](#hvac-action-reason-external-values) | yes |
+
+
 
 ## Configuration variables
 

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -166,6 +166,7 @@ climate:
 
   - platform: dual_smart_thermostat
     name: AUX Heat Room
+    entity_id: aux_heat_room
     heater: switch.heater
     secondary_heater: switch.aux_heater
     secondary_heater_timeout: 00:00:15

--- a/custom_components/dual_smart_thermostat/const.py
+++ b/custom_components/dual_smart_thermostat/const.py
@@ -38,6 +38,7 @@ CONF_HEAT_COOL_MODE = "heat_cool_mode"
 ATTR_TIMEOUT = "timeout"
 PRESET_ANTI_FREEZE = "Anti Freeze"
 
+
 TIMED_OPENING_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_id,

--- a/custom_components/dual_smart_thermostat/hvac_action_reason.py
+++ b/custom_components/dual_smart_thermostat/hvac_action_reason.py
@@ -1,0 +1,44 @@
+from enum import StrEnum
+from itertools import chain
+
+SET_HVAC_ACTION_REASON_SIGNAL = "set_hvac_action_reason_signal_{}"
+SERVICE_SET_HVAC_ACTION_REASON = "set_hvac_action_reason"
+
+
+class HVACActionReasonExternal(StrEnum):
+    """External HVAC Action Reason for climate devices."""
+
+    PRESENCE = "presence"
+
+    SCHEDULE = "schedule"
+
+    EMERGENCY = "emergency"
+
+    MALFUNCTION = "malfunction"
+
+
+class HVACActionReasonInternal(StrEnum):
+    """Internal HVAC Action Reason for climate devices."""
+
+    TARGET_TEMP_NOT_REACHED = "target_temp_not_reached"
+
+    TARGET_TEMP_REACHED = "target_temp_reached"
+
+    MISCONFIGURATION = "misconfiguration"
+
+    OPENING = "opening"
+
+    LIMIT = "limit"
+
+    OVERHEAT = "overheat"
+
+
+class HVACActionReason(StrEnum):
+    """HVAC Action Reason for climate devices."""
+
+    _ignore_ = "member cls"
+    cls = vars()
+    for member in chain(list(HVACActionReasonInternal), list(HVACActionReasonExternal)):
+        cls[member.name] = member.value
+
+    NONE = ""

--- a/custom_components/dual_smart_thermostat/services.yaml
+++ b/custom_components/dual_smart_thermostat/services.yaml
@@ -1,3 +1,23 @@
- reload:
+reload:
    name: Reload Dual Smart Thermostat
    description: Reload all Dual Smart Thermostat entities.
+
+set_hvac_action_reason:
+  name: Sets the reason of the last hvac action.
+  description: Sets the reason of the last hvac action.
+  target:
+    entity:
+      domain: climate
+  fields:
+    hvac_action_reason:
+      required: true
+      selector:
+        select:
+          translation_key: "hac_action_reason"
+          options:
+            - "presence"
+            - "schedule"
+            - "emergency"
+            - "malfunction"
+            - "misconfiguration"
+            - ''

--- a/custom_components/dual_smart_thermostat/translations/en.json
+++ b/custom_components/dual_smart_thermostat/translations/en.json
@@ -1,0 +1,25 @@
+{
+    "selector": {
+        "hac_action_reason": {
+            "options": {
+                "presence": "Presence",
+                "schedule": "Schedule",
+                "emergency": "Emergency",
+                "malfunction": "Malfunction",
+                "misconfiguration": "Misconfiguration"
+            }
+        }
+    },
+    "services": {
+        "set_hvac_action_reason": {
+            "name": "Set HVAC Action Reason",
+            "description": "Sets HVAC action reason.",
+            "fields": {
+                "hvac_action_reason": {
+                    "name": "HVAC Action Reason",
+                    "description": "The reason the last HVAC action was taken."
+                }
+            }
+        }
+    }
+}

--- a/tests/FEATURES.md
+++ b/tests/FEATURES.md
@@ -64,6 +64,7 @@
 | temp change heater trigger off long enough | X | N/A | ! |
 | mode change heater trigger off not long enough | X | N/A | ! |
 | mode change heater trigger on not long enough | X | N/A | ! |
+
 | precision | X | ! | ! |
 | init hvac off force switch off | X | ! | ! |
 | restore will turn off | X | ! | ! |
@@ -73,12 +74,20 @@
 | aux heater keep primary on | X | N/A | N/A |
 | aux heater today | ! | N/A | N/A |
 | tolerance | X | X! | ? |
-| floor temp ! | X | N/A | ? |
+| floor temp | X | N/A | ? |
 | hvac mode cycle | X | X | ? |
 
+## Hvac Action Reason
+
+| Feature | Cool Mode | Heat Mode | Heat Cool Mode |
+| --- | --- | --- | --- |
+| hvac action reason default | X | ! | ! |
+| hvac action reason service | X | ! | ! |
+| floor temp Hvac Action Reason  | X | N/A | X |
+| opening Hvac Action reason | X | X | ! |
 
 ## Openings
 
 | Feature | Cool Mode | Heat Mode | Heat Cool Mode |
 | --- | --- | --- | --- |
-} opening | X | X | ? |
+| opening | X | X | ? |

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -85,6 +85,30 @@ async def setup_comp_heat_floor_sensor(hass):
 
 
 @pytest.fixture
+async def setup_comp_heat_floor_opening_sensor(hass):
+    """Initialize components."""
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": common.ENT_SWITCH,
+                "target_sensor": common.ENT_SENSOR,
+                "floor_sensor": common.ENT_FLOOR_SENSOR,
+                "initial_hvac_mode": HVACMode.HEAT,
+                "openings": [common.ENT_OPENING_SENSOR],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
 async def setup_comp_heat_cycle(hass):
     """Initialize components."""
     hass.config.units = METRIC_SYSTEM

--- a/tests/test_cooler_mode.py
+++ b/tests/test_cooler_mode.py
@@ -29,7 +29,9 @@ from homeassistant.util import dt, dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
 import pytest
 
+from custom_components.dual_smart_thermostat.climate import ATTR_HVAC_ACTION_REASON
 from custom_components.dual_smart_thermostat.const import DOMAIN, PRESET_ANTI_FREEZE
+from custom_components.dual_smart_thermostat.hvac_action_reason import HVACActionReason
 
 from . import (  # noqa: F401
     common,
@@ -840,6 +842,118 @@ async def test_cooler_mode_cycle(
     setup_sensor(hass, 17)
     await hass.async_block_till_done()
     assert hass.states.get(cooler_switch).state == result_state
+
+
+######################
+# HVAC ACTION REASON #
+######################
+
+
+async def test_cooler_mode_opening_hvac_action_reason(
+    hass: HomeAssistant, setup_comp_1  # noqa: F811
+) -> None:
+    """Test thermostat cooler switch in cooling mode."""
+    cooler_switch = "input_boolean.test"
+    opening_1 = "input_boolean.opening_1"
+    opening_2 = "input_boolean.opening_2"
+
+    assert await async_setup_component(
+        hass,
+        input_boolean.DOMAIN,
+        {"input_boolean": {"test": None, "opening_1": None, "opening_2": None}},
+    )
+
+    assert await async_setup_component(
+        hass,
+        input_number.DOMAIN,
+        {
+            "input_number": {
+                "temp": {"name": "test", "initial": 10, "min": 0, "max": 40, "step": 1}
+            }
+        },
+    )
+
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "heater": cooler_switch,
+                "ac_mode": "true",
+                "target_sensor": common.ENT_SENSOR,
+                "initial_hvac_mode": HVACMode.COOL,
+                "openings": [
+                    opening_1,
+                    {"entity_id": opening_2, "timeout": {"seconds": 10}},
+                ],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(common.ENTITY).attributes.get(ATTR_HVAC_ACTION_REASON)
+        == HVACActionReason.NONE
+    )
+
+    setup_sensor(hass, 23)
+    await hass.async_block_till_done()
+
+    await common.async_set_temperature(hass, 18)
+    await hass.async_block_till_done()
+    assert (
+        hass.states.get(common.ENTITY).attributes.get(ATTR_HVAC_ACTION_REASON)
+        == HVACActionReason.TARGET_TEMP_NOT_REACHED
+    )
+
+    setup_boolean(hass, opening_1, "open")
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(common.ENTITY).attributes.get(ATTR_HVAC_ACTION_REASON)
+        == HVACActionReason.OPENING
+    )
+
+    setup_boolean(hass, opening_1, "closed")
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(common.ENTITY).attributes.get(ATTR_HVAC_ACTION_REASON)
+        == HVACActionReason.TARGET_TEMP_NOT_REACHED
+    )
+
+    setup_boolean(hass, opening_2, "open")
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(common.ENTITY).attributes.get(ATTR_HVAC_ACTION_REASON)
+        == HVACActionReason.TARGET_TEMP_NOT_REACHED
+    )
+
+    # wait 10 seconds, actually 133 due to the other tests run time seems to affect this
+    # needs to separate the tests
+    await asyncio.sleep(13)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(common.ENTITY).attributes.get(ATTR_HVAC_ACTION_REASON)
+        == HVACActionReason.OPENING
+    )
+
+    setup_boolean(hass, opening_2, "closed")
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(common.ENTITY).attributes.get(ATTR_HVAC_ACTION_REASON)
+        == HVACActionReason.TARGET_TEMP_NOT_REACHED
+    )
+
+
+############
+# OPENINGS #
+############
 
 
 async def test_cooler_mode_opening(


### PR DESCRIPTION
The reason for the current HVAC action, such as 'idle,' was not provided in the state of the component. This made understanding why the thermostat was idle challenging. For example, a window could be open, or the floor temperature could be too low or high.
This change introduces the `hvac_action_reason` state attribute to provide this extra information. This also introduces a service that lets automation set this attribute for other predefined reasons.

Fixes #129