### PR TITLE
fix: set temps don't restore on HA boot if a preset is set when HA restarts

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -303,7 +303,8 @@ climate:
   - platform: dual_smart_thermostat
     name: FAN Only Room
     unique_id: fan_only_room
-    fan: switch.fan
+    heater: switch.fan
+    fan_mode: true
     fan_hot_tolerance: 2
     fan_on_with_ac: true
     target_sensor: sensor.room_temp

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -528,6 +528,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
 
         else:
             # No previous state, try and restore defaults
+            _LOGGER.debug("No previous state found, setting defaults")
             if not self.hvac_device.hvac_mode:
                 self.hvac_device.hvac_mode = HVACMode.OFF
             if self.hvac_device.hvac_mode == HVACMode.OFF:

--- a/custom_components/dual_smart_thermostat/managers/temperature_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/temperature_manager.py
@@ -2,7 +2,12 @@ import logging
 import math
 from typing import Any
 
-from homeassistant.components.climate import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP
+from homeassistant.components.climate import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
+)
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, State, callback
@@ -387,16 +392,21 @@ class TemperatureManager(StateManager):
             self._target_temp_high += PRECISION_WHOLE
 
     def apply_old_state(self, old_state: State) -> None:
+        _LOGGER.debug("Applying old state: %s", old_state)
         if old_state is None:
             return
 
         # If we have no initial temperature, restore
         if self._target_temp_low is None:
-            old_target_min = old_state.attributes.get(ATTR_PREV_TARGET_LOW)
+            old_target_min = old_state.attributes.get(
+                ATTR_PREV_TARGET_LOW
+            ) or old_state.attributes.get(ATTR_TARGET_TEMP_LOW)
             if old_target_min is not None:
                 self._target_temp_low = float(old_target_min)
         if self._target_temp_high is None:
-            old_target_max = old_state.attributes.get(ATTR_PREV_TARGET_HIGH)
+            old_target_max = old_state.attributes.get(
+                ATTR_PREV_TARGET_HIGH
+            ) or old_state.attributes.get(ATTR_TARGET_TEMP_HIGH)
             if old_target_max is not None:
                 self._target_temp_high = float(old_target_max)
         if self._target_temp is None:


### PR DESCRIPTION
Fixes #184