### PR TITLE
Use differents timeout for opening and closing on tests

### DIFF
--- a/tests/test_cooler_mode.py
+++ b/tests/test_cooler_mode.py
@@ -1334,7 +1334,7 @@ async def test_cooler_mode_opening_hvac_action_reason(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -1410,7 +1410,7 @@ async def test_cooler_mode_opening_hvac_action_reason(
     #     hass, dt_util.utcnow() + datetime.timedelta(seconds=15)
     # )
     # await asyncio.sleep(5)
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -1638,7 +1638,7 @@ async def test_cooler_mode_opening(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -1692,7 +1692,7 @@ async def test_cooler_mode_opening(
     # common.async_fire_time_changed(
     #     hass, dt_util.utcnow() + datetime.timedelta(minutes=10)
     # )
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/test_dry_mode.py
+++ b/tests/test_dry_mode.py
@@ -1398,7 +1398,7 @@ async def test_dryer_mode_opening_hvac_action_reason(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -1469,7 +1469,7 @@ async def test_dryer_mode_opening_hvac_action_reason(
     )
 
     # wait openings
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -1549,7 +1549,7 @@ async def test_dryer_mode_opening(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -1599,7 +1599,7 @@ async def test_dryer_mode_opening(
     assert hass.states.get(dryer_switch).state == STATE_OFF
 
     # wait openings
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/test_dual_mode.py
+++ b/tests/test_dual_mode.py
@@ -3786,7 +3786,7 @@ async def test_heat_cool_mode_opening_timeout(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -3876,7 +3876,7 @@ async def test_heat_cool_mode_opening_timeout(
     assert hass.states.get(cooler_switch).state == STATE_OFF
 
     # wait openings
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/test_fan_mode.py
+++ b/tests/test_fan_mode.py
@@ -3060,7 +3060,7 @@ async def test_fan_mode_opening_hvac_action_reason(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -3130,7 +3130,7 @@ async def test_fan_mode_opening_hvac_action_reason(
     )
 
     # wait openings
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -3200,7 +3200,7 @@ async def test_cooler_fan_mode_opening_hvac_action_reason(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -3270,7 +3270,7 @@ async def test_cooler_fan_mode_opening_hvac_action_reason(
     )
 
     # wait openings
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -3325,7 +3325,7 @@ async def test_fan_mode_opening(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -3374,7 +3374,7 @@ async def test_fan_mode_opening(
     assert hass.states.get(cooler_switch).state == STATE_OFF
 
     # wait openings
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -3441,7 +3441,7 @@ async def test_cooler_fan_mode_opening(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -3521,7 +3521,7 @@ async def test_cooler_fan_mode_opening(
     assert hass.states.get(fan_switch).state == STATE_OFF
 
     # wait openings
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/test_heater_mode.py
+++ b/tests/test_heater_mode.py
@@ -2299,7 +2299,7 @@ async def test_heater_mode_opening_hvac_action_reason(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -2368,7 +2368,7 @@ async def test_heater_mode_opening_hvac_action_reason(
     )
 
     # wait openings
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -2480,7 +2480,7 @@ async def test_heater_mode_opening(
                     {
                         "entity_id": opening_2,
                         "timeout": {"seconds": 5},
-                        "closing_timeout": {"seconds": 5},
+                        "closing_timeout": {"seconds": 3},
                     },
                 ],
             }
@@ -2529,7 +2529,7 @@ async def test_heater_mode_opening(
     assert hass.states.get(heater_switch).state == STATE_OFF
 
     # wait openings
-    freezer.tick(timedelta(seconds=6))
+    freezer.tick(timedelta(seconds=4))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
Follow up to PR #389 tests.

I just thought that should be better use different timeout for opening and closing on tests, so that we can be sure that we are using the right timeout setting.
