### PR TITLE
Fix min-cycle-duration and keep-alive options

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ The internal values can be set by the component only and the external values can
 
 ### min_cycle_duration
 
-  _(optional) (time, integer)_  Set a minimum amount of time that the switch specified in the _heater_  and/or _cooler_ option must be in its current state prior to being switched either off or on.
+  _(optional) (time, integer)_  Set a minimum amount of time that the switch specified in the _heater_  and/or _cooler_ option must be in its current state prior to being switched either off or on. This option will be ignored if the `keep_alive` option is set.
 
 ### cold_tolerance
 
@@ -611,7 +611,7 @@ The internal values can be set by the component only and the external values can
 
 ### keep_alive
 
-  _(optional) (time, integer)_ Set a keep-alive interval. If set, the switch specified in the _heater_ and/or _cooler_ option will be triggered every time the interval elapses. Use with heaters and A/C units that shut off if they don't receive a signal from their remote for a while. Use also with switches that might lose state. The keep-alive call is done with the current valid climate integration state (either on or off).
+  _(optional) (time, integer)_ Set a keep-alive interval. If set, the switch specified in the _heater_ and/or _cooler_ option will be triggered every time the interval elapses. Use with heaters and A/C units that shut off if they don't receive a signal from their remote for a while. Use also with switches that might lose state. The keep-alive call is done with the current valid climate integration state (either on or off). When `keep_alive` is set the `min_cycle_duration` option will be ignored.
 
 ### initial_hvac_mode
 
@@ -845,8 +845,7 @@ climate:
     cold_tolerance: 0.3
     hot_tolerance: 0
     min_cycle_duration:
-      seconds: 5
-      seconds: 5
+      minutes: 5
     keep_alive:
       minutes: 3
     initial_hvac_mode: "off" # hvac mode will reset to this value after restart

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -1246,7 +1246,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
 
         async with self._temp_lock:
 
-            if self.hvac_device.hvac_mode == HVACMode.OFF:
+            if self.hvac_device.hvac_mode == HVACMode.OFF and time is None:
                 _LOGGER.debug("Climate is off, skipping control")
                 return
 

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -143,6 +143,7 @@ from .const import (
     DEFAULT_MAX_FLOOR_TEMP,
     DEFAULT_NAME,
     DEFAULT_TOLERANCE,
+    MIN_CYCLE_KEEP_ALIVE,
     TIMED_OPENING_SCHEMA,
 )
 from .hvac_action_reason.hvac_action_reason import (
@@ -293,6 +294,15 @@ async def async_setup_platform(
     sensor_heat_pump_cooling_entity_id = config.get(CONF_HEAT_PUMP_COOLING)
     keep_alive = config.get(CONF_KEEP_ALIVE)
 
+    # we ignore min cycle duration if keep alive is configured (conflicting config)
+    if keep_alive is not None:
+        if CONF_MIN_DUR in config:
+            _LOGGER.warning(
+                "The configuration option 'min_cycle_duration' will be ignored "
+                "beacuse incompatible with the defined option 'keep_alive'."
+            )
+            config.pop(CONF_MIN_DUR)
+
     precision = config.get(CONF_PRECISION)
     unit = hass.config.units.temperature_unit
     unique_id = config.get(CONF_UNIQUE_ID)
@@ -316,6 +326,7 @@ async def async_setup_platform(
         environment_manager, opening_manager, hvac_power_manager
     )
 
+    has_min_cycle = CONF_MIN_DUR in config
     async_add_entities(
         [
             DualSmartThermostat(
@@ -327,6 +338,7 @@ async def async_setup_platform(
                 sensor_stale_duration,
                 sensor_heat_pump_cooling_entity_id,
                 keep_alive,
+                has_min_cycle,
                 precision,
                 unit,
                 unique_id,
@@ -381,7 +393,8 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         sensor_humidity_entity_id,
         sensor_stale_duration,
         sensor_heat_pump_cooling_entity_id,
-        keep_alive,
+        keep_alive: timedelta | None,
+        has_min_cycle: bool,
         precision,
         unit,
         unique_id,
@@ -423,6 +436,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         self.sensor_heat_pump_cooling_entity_id = sensor_heat_pump_cooling_entity_id
 
         self._keep_alive = keep_alive
+        self._has_min_cycle = has_min_cycle
 
         self._sensor_stale_duration = sensor_stale_duration
         self._remove_stale_tracking: Callable[[], None] | None = None
@@ -474,7 +488,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
 
         switch_entities = self.hvac_device.get_device_ids()
         if switch_entities:
-            _LOGGER.info("Adding switch listener: %s", switch_entities)
+            _LOGGER.debug("Adding switch listener: %s", switch_entities)
             self.async_on_remove(
                 async_track_state_change_event(
                     self.hass, switch_entities, self._async_switch_changed_event
@@ -533,12 +547,25 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
                 )
             )
 
-        if self._keep_alive:
-            self.async_on_remove(
-                async_track_time_interval(
-                    self.hass, self._async_control_climate, self._keep_alive
+        if self._keep_alive or self._has_min_cycle:
+            if self._keep_alive:
+                self.async_on_remove(
+                    async_track_time_interval(
+                        self.hass,
+                        self._async_control_climate,
+                        self._keep_alive,
+                    )
                 )
-            )
+            else:
+                # when min_cycle_duration is set and no keep-alive defined
+                # we poll every 60 seconds to check conditions
+                self.async_on_remove(
+                    async_track_time_interval(
+                        self.hass,
+                        self._async_control_climate_no_time,
+                        timedelta(seconds=MIN_CYCLE_KEEP_ALIVE),
+                    )
+                )
 
         if self.openings.opening_entities:
             self.async_on_remove(
@@ -549,7 +576,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
                 )
             )
 
-        _LOGGER.info(
+        _LOGGER.debug(
             "Setting up signal: %s",
             SET_HVAC_ACTION_REASON_SIGNAL.format(self.entity_id),
         )
@@ -898,7 +925,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         hvac_mode = kwargs.get(ATTR_HVAC_MODE)
 
-        _LOGGER.info(
+        _LOGGER.debug(
             "Setting temperatures. Temp: %s, Low: %s, High: %s, Hvac Mode: %s",
             temperature,
             temp_low,
@@ -909,7 +936,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         temperatures = TargetTemperatures(temperature, temp_high, temp_low)
 
         if hvac_mode is not None:
-            _LOGGER.info("Setting hvac mode with temperature: %s", hvac_mode)
+            _LOGGER.debug("Setting hvac mode with temperature: %s", hvac_mode)
             await self.async_set_hvac_mode(hvac_mode)
 
         if self.features.is_configured_for_heat_cool_mode:
@@ -925,7 +952,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
 
     async def async_set_humidity(self, humidity: float) -> None:
         """Set new target humidity."""
-        _LOGGER.info("Setting humidity: %s", humidity)
+        _LOGGER.debug("Setting humidity: %s", humidity)
 
         self.environment.target_humidity = humidity
         self._target_humidity = self.environment.target_humidity
@@ -984,7 +1011,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         self, new_state: State | None, trigger_control=True
     ) -> None:
         """Handle temperature changes."""
-        _LOGGER.info(
+        _LOGGER.debug(
             "Sensor change: %s, trigger_control: %s", new_state, trigger_control
         )
         if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
@@ -1068,7 +1095,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         self, new_state: State | None, trigger_control=True
     ) -> None:
         """Handle floor temperature changes."""
-        _LOGGER.info("Sensor floor change: %s", new_state)
+        _LOGGER.debug("Sensor floor change: %s", new_state)
         if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return
 
@@ -1090,7 +1117,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         self, new_state: State | None, trigger_control=True
     ) -> None:
         """Handle outside temperature changes."""
-        _LOGGER.info("Sensor outside change: %s", new_state)
+        _LOGGER.debug("Sensor outside change: %s", new_state)
         if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return
 
@@ -1112,7 +1139,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         self, new_state: State | None, trigger_control=True
     ) -> None:
         """Handle humidity changes."""
-        _LOGGER.info("Sensor humidity change: %s", new_state)
+        _LOGGER.debug("Sensor humidity change: %s", new_state)
         if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return
 
@@ -1215,7 +1242,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
     async def _async_control_climate(self, time=None, force=False) -> None:
         """Control the climate device based on config."""
 
-        _LOGGER.info("Attempting to control climate, time %s, force %s", time, force)
+        _LOGGER.debug("Attempting to control climate, time %s, force %s", time, force)
 
         async with self._temp_lock:
 
@@ -1225,17 +1252,22 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
 
             await self.hvac_device.async_control_hvac(time, force)
 
-            _LOGGER.info(
+            _LOGGER.debug(
                 "updating HVACActionReason: %s", self.hvac_device.HVACActionReason
             )
 
             self._hvac_action_reason = self.hvac_device.HVACActionReason
 
     async def _async_control_climate_forced(self, time=None) -> None:
-        _LOGGER.info("Attempting to forcefully control climate, time %s", time)
-        await self._async_control_climate(force=True, time=time)
+        """Forcefully control the climate device based on config."""
+        _LOGGER.debug("Attempting to forcefully control climate, time %s", time)
+        await self._async_control_climate(time=None, force=True)
 
         self.async_write_ha_state()
+
+    async def _async_control_climate_no_time(self, time=None, force=False) -> None:
+        """Control the climate device based on config removing time param."""
+        await self._async_control_climate(time=None, force=force)
 
     @callback
     def _async_hvac_mode_changed(self, hvac_mode) -> None:

--- a/custom_components/dual_smart_thermostat/const.py
+++ b/custom_components/dual_smart_thermostat/const.py
@@ -19,6 +19,8 @@ DEFAULT_TOLERANCE = 0.3
 DEFAULT_NAME = "Dual Smart Thermostat"
 DEFAULT_MAX_FLOOR_TEMP = 28.0
 
+MIN_CYCLE_KEEP_ALIVE = 60.0
+
 DOMAIN = "dual_smart_thermostat"
 
 CONF_HEATER = "heater"

--- a/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
+++ b/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
@@ -199,7 +199,7 @@ class GenericHvacController(HvacController):
             await self.async_turn_on_callback()
             self._hvac_action_reason = strategy.goal_not_reached_reason()
 
-        elif time is not None or any_opening_open:
+        elif time is not None:
             # The time argument is passed only in keep-alive case
             _LOGGER.info("Keep-alive - Turning off entity %s", self.entity_id)
             await self.async_turn_off_callback()

--- a/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
+++ b/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
@@ -72,7 +72,7 @@ class GenericHvacController(HvacController):
         """If the toggleable hvac device is currently active."""
         on_state = STATE_OPEN if self._is_valve else STATE_ON
 
-        _LOGGER.info(
+        _LOGGER.debug(
             "Checking if device is active: %s, on_state: %s",
             self.entity_id,
             on_state,
@@ -137,8 +137,11 @@ class GenericHvacController(HvacController):
         time=None,
     ) -> None:
         """Check if we need to turn heating on or off when theheater is on."""
-
-        _LOGGER.info("%s Controlling hvac while on", self.__class__.__name__)
+        _LOGGER.debug(
+            "%s Controlling hvac entity %s while on",
+            self.__class__.__name__,
+            self.entity_id,
+        )
         _LOGGER.debug("below_env_attr: %s", strategy.hvac_goal_reached)
         _LOGGER.debug("any_opening_open: %s", any_opening_open)
         _LOGGER.debug("hvac_goal_reached: %s", strategy.hvac_goal_reached)
@@ -176,7 +179,11 @@ class GenericHvacController(HvacController):
         time=None,
     ) -> None:
         """Check if we need to turn heating on or off when the heater is off."""
-        _LOGGER.info("%s Controlling hvac while off", self.__class__.__name__)
+        _LOGGER.debug(
+            "%s Controlling hvac entity %s while off",
+            self.__class__.__name__,
+            self.entity_id,
+        )
         _LOGGER.debug("above_env_attr: %s", strategy.hvac_goal_reached)
         _LOGGER.debug("below_env_attr: %s", strategy.hvac_goal_not_reached)
         _LOGGER.debug("any_opening_open: %s", any_opening_open)
@@ -188,8 +195,10 @@ class GenericHvacController(HvacController):
                 "Turning on entity (from inactive) due to hvac goal is not reached %s",
                 self.entity_id,
             )
+
             await self.async_turn_on_callback()
             self._hvac_action_reason = strategy.goal_not_reached_reason()
+
         elif time is not None or any_opening_open:
             # The time argument is passed only in keep-alive case
             _LOGGER.info("Keep-alive - Turning off entity %s", self.entity_id)

--- a/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
+++ b/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
@@ -110,7 +110,7 @@ class GenericHvacController(HvacController):
         self, active: bool, hvac_mode: HVACMode, time=None, force=False
     ) -> bool:
         """Checks if the controller needs to continue."""
-        if not active or hvac_mode == HVACMode.OFF:
+        if (not active or hvac_mode == HVACMode.OFF) and time is None:
             _LOGGER.debug(
                 "Not active or hvac mode is off active: %s, _hvac_mode: %s",
                 active,

--- a/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
@@ -61,7 +61,7 @@ class ControlableHVACDevice(ABC):
                 await self.async_turn_off()
             self._hvac_action_reason = HVACActionReason.NONE
         else:
-            await self.async_control_hvac(self, force=True)
+            await self.async_control_hvac(force=True)
 
         _LOGGER.info("Hvac mode set to %s", self._hvac_mode)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
@@ -57,7 +57,8 @@ class ControlableHVACDevice(ABC):
             self.hvac_mode = HVACMode.OFF
 
         if self.hvac_mode == HVACMode.OFF:
-            await self.async_turn_off()
+            if self.is_active:
+                await self.async_turn_off()
             self._hvac_action_reason = HVACActionReason.NONE
         else:
             await self.async_control_hvac(self, force=True)

--- a/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
@@ -132,11 +132,12 @@ class CoolerFanDevice(MultiHvacDevice):
                     await self._async_control_cooler(time, force)
 
             case HVACMode.FAN_ONLY:
-                await self.cooler_device.async_turn_off()
+                if self.cooler_device.is_active:
+                    await self.cooler_device.async_turn_off()
                 await self.fan_device.async_control_hvac(time, force)
                 self.HVACActionReason = self.fan_device.HVACActionReason
             case HVACMode.OFF:
-                await self.async_turn_off()
+                await self.async_turn_off_all(time=time)
                 self.HVACActionReason = HVACActionReason.NONE
             case _:
                 if self._hvac_mode is not None:
@@ -184,11 +185,13 @@ class CoolerFanDevice(MultiHvacDevice):
 
             self.fan_device.hvac_mode = HVACMode.FAN_ONLY
             await self.fan_device.async_control_hvac(time, force_override)
-            await self.cooler_device.async_turn_off()
+            if self.cooler_device.is_active:
+                await self.cooler_device.async_turn_off()
             self.HVACActionReason = HVACActionReason.TARGET_TEMP_NOT_REACHED_WITH_FAN
         else:
             _LOGGER.debug("outside fan tolerance")
             _LOGGER.debug("fan_hot_tolerance_on: %s", self._fan_hot_tolerance_on)
             await self.cooler_device.async_control_hvac(time, force_override)
-            await self.fan_device.async_turn_off()
+            if self.fan_device.is_active:
+                await self.fan_device.async_turn_off()
             self.HVACActionReason = self.cooler_device.HVACActionReason

--- a/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 import logging
-from typing import Callable
+from typing import Callable, Generic
 
 from homeassistant.components.climate import HVACMode
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -9,6 +9,9 @@ from homeassistant.helpers.event import async_track_state_change_event
 
 from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
     HVACActionReason,
+)
+from custom_components.dual_smart_thermostat.hvac_device.generic_hvac_device import (
+    GenericHVACDevice,
 )
 from custom_components.dual_smart_thermostat.hvac_device.multi_hvac_device import (
     MultiHvacDevice,
@@ -31,7 +34,7 @@ class CoolerFanDevice(MultiHvacDevice):
     def __init__(
         self,
         hass: HomeAssistant,
-        devices: list,
+        devices: list[GenericHVACDevice],
         initial_hvac_mode: HVACMode,
         environment: EnvironmentManager,
         openings: OpeningManager,

--- a/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
@@ -270,7 +270,7 @@ class GenericHVACDevice(
             await self.async_turn_off()
 
     async def async_turn_on(self):
-        _LOGGER.info(
+        _LOGGER.debug(
             "%s. Turning on or opening entity %s",
             self.__class__.__name__,
             self.entity_id,
@@ -285,7 +285,7 @@ class GenericHVACDevice(
             await self._async_turn_on_entity()
 
     async def async_turn_off(self):
-        _LOGGER.info(
+        _LOGGER.debug(
             "%s. Turning off or closing entity %s",
             self.__class__.__name__,
             self.entity_id,
@@ -308,29 +308,16 @@ class GenericHVACDevice(
             "%s. Turning on entity %s", self.__class__.__name__, self.entity_id
         )
 
-        if self.entity_id is not None and self.hass.states.is_state(
-            self.entity_id, STATE_OFF
-        ):
-            _LOGGER.debug("Turning on entity if state not on %s", self.entity_id)
-            try:
-                await self.hass.services.async_call(
-                    HA_DOMAIN,
-                    SERVICE_TURN_ON,
-                    {ATTR_ENTITY_ID: self.entity_id},
-                    context=self._context,
-                    blocking=True,
-                )
-            except Exception as e:
-                _LOGGER.error(
-                    "Error turning on entity %s. Error: %s", self.entity_id, e
-                )
-            # await self.hass.services.async_call(
-            #     HA_DOMAIN,
-            #     SERVICE_TURN_ON,
-            #     {ATTR_ENTITY_ID: self.entity_id},
-            #     context=self._context,
-            #     blocking=True,
-            # )
+        try:
+            await self.hass.services.async_call(
+                HA_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: self.entity_id},
+                context=self._context,
+                blocking=True,
+            )
+        except Exception as e:
+            _LOGGER.error("Error turning on entity %s. Error: %s", self.entity_id, e)
 
     async def _async_turn_off_entity(self) -> None:
         """Turn off the entity."""
@@ -338,9 +325,7 @@ class GenericHVACDevice(
             "%s. Turning off entity %s", self.__class__.__name__, self.entity_id
         )
 
-        if self.entity_id is not None and self.hass.states.is_state(
-            self.entity_id, STATE_ON
-        ):
+        try:
             await self.hass.services.async_call(
                 HA_DOMAIN,
                 SERVICE_TURN_OFF,
@@ -348,14 +333,14 @@ class GenericHVACDevice(
                 context=self._context,
                 blocking=True,
             )
+        except Exception as e:
+            _LOGGER.error("Error turning off entity %s. Error: %s", self.entity_id, e)
 
     async def _async_open_valve_entity(self) -> None:
         """Open the entity."""
         _LOGGER.info("%s. Opening entity %s", self.__class__.__name__, self.entity_id)
 
-        if self.entity_id is not None and self.hass.states.is_state(
-            self.entity_id, STATE_CLOSED
-        ):
+        try:
             await self.hass.services.async_call(
                 HA_DOMAIN,
                 SERVICE_OPEN_VALVE,
@@ -363,14 +348,14 @@ class GenericHVACDevice(
                 context=self._context,
                 blocking=True,
             )
+        except Exception as e:
+            _LOGGER.error("Error opening entity %s. Error: %s", self.entity_id, e)
 
     async def _async_close_valve_entity(self) -> None:
         """Close the entity."""
         _LOGGER.info("%s. Closing entity %s", self.__class__.__name__, self.entity_id)
 
-        if self.entity_id is not None and self.hass.states.is_state(
-            self.entity_id, STATE_OPEN
-        ):
+        try:
             await self.hass.services.async_call(
                 HA_DOMAIN,
                 SERVICE_CLOSE_VALVE,
@@ -378,3 +363,5 @@ class GenericHVACDevice(
                 context=self._context,
                 blocking=True,
             )
+        except Exception as e:
+            _LOGGER.error("Error closing entity %s. Error: %s", self.entity_id, e)

--- a/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
@@ -203,16 +203,11 @@ class GenericHVACDevice(
 
         self._set_self_active()
 
-        _LOGGER.debug(
-            "needs_control: %s",
-            self.hvac_controller.needs_control(
-                self._active, self.hvac_mode, time, force
-            ),
-        )
-
+        _LOGGER.debug("Check if needs control.")
         if not self.hvac_controller.needs_control(
             self._active, self.hvac_mode, time, force
         ):
+            _LOGGER.debug("Control not needed. exit.")
             return
 
         any_opening_open = self.openings.any_opening_open(self.hvac_mode)

--- a/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
@@ -130,7 +130,7 @@ class MultiHvacDevice(HVACDevice, ControlableHVACDevice):
 
         self.set_sub_devices_hvac_mode(hvac_mode)
 
-        await self.async_control_hvac(self, force=True)
+        await self.async_control_hvac(force=True)
 
         _LOGGER.info("Hvac mode set to %s", self._hvac_mode)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -313,6 +313,30 @@ async def setup_comp_fan_only_config_cycle(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
+async def setup_comp_fan_only_config_keep_alive(hass: HomeAssistant) -> None:
+    """Initialize components."""
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "fan_mode": "true",
+                "heater": common.ENT_SWITCH,
+                "target_sensor": common.ENT_SENSOR,
+                "initial_hvac_mode": HVACMode.FAN_ONLY,
+                "keep_alive": datetime.timedelta(minutes=10),
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
 async def setup_comp_fan_only_config_presets(hass: HomeAssistant) -> None:
     """Initialize components."""
     hass.config.units = METRIC_SYSTEM
@@ -442,6 +466,32 @@ async def setup_comp_heat_ac_cool_fan_config_cycle(hass: HomeAssistant) -> None:
                 "fan": common.ENT_FAN,
                 "initial_hvac_mode": HVACMode.OFF,
                 "min_cycle_duration": datetime.timedelta(minutes=10),
+                PRESET_AWAY: {"temperature": 30},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
+async def setup_comp_heat_ac_cool_fan_config_keep_alive(hass: HomeAssistant) -> None:
+    """Initialize components."""
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "ac_mode": True,
+                "heater": common.ENT_SWITCH,
+                "target_sensor": common.ENT_SENSOR,
+                "fan": common.ENT_FAN,
+                "initial_hvac_mode": HVACMode.OFF,
+                "keep_alive": datetime.timedelta(minutes=10),
                 PRESET_AWAY: {"temperature": 30},
             }
         },
@@ -594,33 +644,6 @@ async def setup_comp_heat_ac_cool_cycle(hass: HomeAssistant) -> None:
                 "target_sensor": common.ENT_SENSOR,
                 "initial_hvac_mode": HVACMode.COOL,
                 "min_cycle_duration": datetime.timedelta(minutes=10),
-                PRESET_AWAY: {"temperature": 30},
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-
-@pytest.fixture
-async def setup_comp_heat_ac_cool_cycle_kepp_alive(hass: HomeAssistant) -> None:
-    """Initialize components."""
-    hass.config.units = METRIC_SYSTEM
-    hass.config.temperature_unit = UnitOfTemperature.CELSIUS
-    assert await async_setup_component(
-        hass,
-        CLIMATE,
-        {
-            "climate": {
-                "platform": DOMAIN,
-                "name": "test",
-                "cold_tolerance": 0.3,
-                "hot_tolerance": 0.3,
-                "ac_mode": True,
-                "heater": common.ENT_SWITCH,
-                "target_sensor": common.ENT_SENSOR,
-                "initial_hvac_mode": HVACMode.COOL,
-                "min_cycle_duration": datetime.timedelta(minutes=10),
-                "keep_alive": datetime.timedelta(minutes=10),
                 PRESET_AWAY: {"temperature": 30},
             }
         },

--- a/tests/test_cooler_mode.py
+++ b/tests/test_cooler_mode.py
@@ -4,7 +4,6 @@ import datetime
 from datetime import timedelta
 import logging
 
-from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 from homeassistant.components import input_boolean, input_number
 from homeassistant.components.climate import (
@@ -37,6 +36,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt, dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
 import pytest
+
 
 from custom_components.dual_smart_thermostat.const import (
     ATTR_HVAC_ACTION_REASON,
@@ -680,183 +680,125 @@ async def test_no_state_change_when_operation_mode_off_2(
     assert len(calls) == 0
 
 
-async def test_temp_change_ac_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_temp_change_ac_trigger_long_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_heat_ac_cool_cycle,  # noqa: F811
 ) -> None:
-    """Test if temperature change turn ac on."""
-    calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
+    """Test if temperature change turn ac on or off."""
+    calls = setup_switch(hass, sw_on)
+    await common.async_set_temperature(hass, 28)
+    setup_sensor(hass, 30 if sw_on else 25)
     await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set temperature to switch
+    setup_sensor(hass, 25 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
     assert len(calls) == 0
 
-
-async def test_temp_change_ac_trigger_on_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
+    # move back to no switch temp
+    setup_sensor(hass, 30 if sw_on else 25)
     await hass.async_block_till_done()
+
+    # go over cycle time
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # no call, not needed
+    assert len(calls) == 0
+
+    # set temperature to switch
+    setup_sensor(hass, 25 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # call triggered, time is enought and temp reached
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_SWITCH
 
 
-async def test_temp_change_ac_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_time_change_ac_trigger_long_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_heat_ac_cool_cycle,  # noqa: F811
 ) -> None:
-    """Test if temperature change turn ac on."""
-    calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
+    """Test if temperature change turn ac on or off when cycle time is past."""
+    calls = setup_switch(hass, sw_on)
+    await common.async_set_temperature(hass, 28)
+    setup_sensor(hass, 30 if sw_on else 25)
     await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set temperature to switch
+    setup_sensor(hass, 25 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
     assert len(calls) == 0
 
-
-async def test_temp_change_ac_trigger_off_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
+    # complete cycle time
+    freezer.tick(timedelta(minutes=5))
+    common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    # call triggered, time is enought
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_SWITCH
 
 
-async def test_mode_change_ac_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_mode_change_ac_trigger_not_long_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_heat_ac_cool_cycle,  # noqa: F811
 ) -> None:
-    """Test if mode change turns ac off despite minimum cycle."""
-    calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
+    """Test if mode change turns ac off or on despite minimum cycle."""
+    calls = setup_switch(hass, sw_on)
+    await common.async_set_temperature(hass, 28)
+    setup_sensor(hass, 30 if sw_on else 25)
     await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
 
-
-async def test_mode_change_ac_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac on despite minimum cycle."""
-    calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_SWITCH
 
-
-async def test_temp_change_ac_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
+    # set temperature to switch
+    setup_sensor(hass, 25 if sw_on else 30)
     await hass.async_block_till_done()
+
+    # no call, not enought time
     assert len(calls) == 0
 
+    # change HVAC mode
+    await common.async_set_hvac_mode(hass, HVACMode.OFF if sw_on else HVACMode.COOL)
 
-async def test_temp_change_ac_trigger_on_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_temp_change_ac_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_ac_trigger_off_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_mode_change_ac_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac off despite minimum cycle."""
-    calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_mode_change_ac_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac on despite minimum cycle."""
-    calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_SWITCH
 
 
@@ -1237,8 +1179,13 @@ async def test_cooler_mode_tolerance(
     ],
 )
 @pytest.mark.asyncio
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_cooler_mode_cycle(
-    hass: HomeAssistant, duration, result_state, setup_comp_1  # noqa: F811
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    duration,
+    result_state,
+    setup_comp_1,  # noqa: F811
 ) -> None:
     """Test thermostat cooler switch in cooling mode with cycle duration."""
     cooler_switch = "input_boolean.test"
@@ -1278,11 +1225,13 @@ async def test_cooler_mode_cycle(
     setup_sensor(hass, 23)
     await hass.async_block_till_done()
 
-    fake_changed = dt.utcnow() - duration
-    with freeze_time(fake_changed):
-        await common.async_set_temperature(hass, 18)
-        await hass.async_block_till_done()
-        assert hass.states.get(cooler_switch).state == STATE_ON
+    await common.async_set_temperature(hass, 18)
+    await hass.async_block_till_done()
+    assert hass.states.get(cooler_switch).state == STATE_ON
+
+    freezer.tick(duration)
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     setup_sensor(hass, 17)
     await hass.async_block_till_done()

--- a/tests/test_cooler_mode.py
+++ b/tests/test_cooler_mode.py
@@ -59,7 +59,6 @@ from . import (  # noqa: F401
     setup_comp_1,
     setup_comp_heat_ac_cool,
     setup_comp_heat_ac_cool_cycle,
-    setup_comp_heat_ac_cool_cycle_kepp_alive,
     setup_comp_heat_ac_cool_fan_config,
     setup_comp_heat_ac_cool_presets,
     setup_comp_heat_ac_cool_presets_range,

--- a/tests/test_dry_mode.py
+++ b/tests/test_dry_mode.py
@@ -4,7 +4,6 @@ import datetime
 from datetime import timedelta
 import logging
 
-from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 from homeassistant.components import input_boolean, input_number
 from homeassistant.components.climate import (
@@ -664,183 +663,109 @@ async def setup_comp_heat_ac_cool_dry_cycle(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_temp_change_ac_dry_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_temp_change_ac_dry_trigger_on_long_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_heat_ac_cool_dry_cycle,  # noqa: F811
 ) -> None:
     """Test if humidity change turn dryer on."""
-    calls = setup_switch_dual(hass, common.ENT_DRYER, False, False)
+    calls = setup_switch_dual(hass, common.ENT_DRYER, False, sw_on)
     await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 71)
+    setup_humidity_sensor(hass, 71 if sw_on else 50)
     await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set humidity to switch
+    setup_humidity_sensor(hass, 50 if sw_on else 71)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
     assert len(calls) == 0
 
-
-async def test_temp_change_ac_dry_trigger_on_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
-) -> None:
-    """Test if humidity change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch_dual(hass, common.ENT_DRYER, False, False)
-    await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 71)
+    # move back to no switch humidity
+    setup_humidity_sensor(hass, 71 if sw_on else 50)
     await hass.async_block_till_done()
+
+    # go over cycle time
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # no call, not needed
+    assert len(calls) == 0
+
+    # set humidity to switch
+    setup_humidity_sensor(hass, 50 if sw_on else 71)
+    await hass.async_block_till_done()
+
+    # call triggered, time is enought and humidity reached
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_DRYER
 
 
-async def test_temp_change_ac_dry_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_time_change_ac_dry_trigger_on_long_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_heat_ac_cool_dry_cycle,  # noqa: F811
 ) -> None:
-    """Test if humidity change turn ac on."""
-    calls = setup_switch_dual(hass, common.ENT_DRYER, False, False)
+    """Test if humidity change turn dryer on when cycle time is past."""
+    calls = setup_switch_dual(hass, common.ENT_DRYER, False, sw_on)
     await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 71)
+    setup_humidity_sensor(hass, 71 if sw_on else 50)
     await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set humidity to switch
+    setup_humidity_sensor(hass, 50 if sw_on else 71)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
     assert len(calls) == 0
 
-
-async def test_temp_change_ac_dry_trigger_off_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
-) -> None:
-    """Test if himidity change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch_dual(hass, common.ENT_DRYER, False, True)
-    await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 50)
+    # go over cycle time
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    # call triggered, time is enought and humidity reached
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_DRYER
 
 
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_mode_change_ac_dry_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
+    hass: HomeAssistant, sw_on, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
 ) -> None:
-    """Test if mode change turns ac off despite minimum cycle."""
-    calls = setup_switch_dual(hass, common.ENT_DRYER, False, True)
+    """Test if mode change turns dryer despite minimum cycle."""
+    calls = setup_switch_dual(hass, common.ENT_DRYER, False, sw_on)
     await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 50)
+    setup_humidity_sensor(hass, 71 if sw_on else 50)
     await hass.async_block_till_done()
     assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_DRYER
-
-
-async def test_mode_change_ac_dry_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac on despite minimum cycle."""
-    calls = setup_switch_dual(hass, common.ENT_DRYER, False, False)
-    await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 70)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.DRY)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_DRYER
-
-
-async def test_temp_change_ac_dry_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
-) -> None:
-    """Test if humidity change turn ac on."""
-    calls = setup_switch_dual(hass, common.ENT_DRYER, False, False)
-    await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 70)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_ac_dryer_trigger_on_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
-) -> None:
-    """Test if humidity change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch_dual(hass, common.ENT_DRYER, False, False)
-    await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 70)
-    await hass.async_block_till_done()
+    await common.async_set_hvac_mode(hass, HVACMode.OFF if sw_on else HVACMode.DRY)
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_DRYER
-
-
-async def test_temp_change_ac_dry_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
-) -> None:
-    """Test if humidity change turn ac on."""
-    calls = setup_switch_dual(hass, common.ENT_DRYER, False, True)
-    await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 50)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_ac_dry_trigger_off_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
-) -> None:
-    """Test if humidity change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch_dual(hass, common.ENT_DRYER, False, True)
-    await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 50)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_DRYER
-
-
-async def test_mode_change_ac_dry_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac off despite minimum cycle."""
-    calls = setup_switch_dual(hass, common.ENT_DRYER, False, True)
-    await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 50)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_DRYER
-
-
-async def test_mode_change_ac_dry_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_dry_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac on despite minimum cycle."""
-    calls = setup_switch_dual(hass, common.ENT_DRYER, False, False)
-    await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 70)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.DRY)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_DRYER
 
 
@@ -1270,9 +1195,13 @@ async def test_dryer_mode_tolerance(
         (timedelta(seconds=30), STATE_OFF),
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_dryer_mode_cycle(
-    hass: HomeAssistant, duration, result_state, setup_comp_1  # noqa: F811
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    duration,
+    result_state,
+    setup_comp_1,  # noqa: F811
 ) -> None:
     """Test thermostat dryer switch in cooling mode with cycle duration."""
     cooler_switch = "input_boolean.test"
@@ -1324,12 +1253,13 @@ async def test_dryer_mode_cycle(
     setup_humidity_sensor(hass, 70)
     await hass.async_block_till_done()
 
-    fake_changed = dt.utcnow() - duration
-    common.async_fire_time_changed(hass, fake_changed)
-    with freeze_time(fake_changed):
-        await common.async_set_humidity(hass, 60)
-        await hass.async_block_till_done()
-        assert hass.states.get(dryer_switch).state == STATE_ON
+    await common.async_set_humidity(hass, 60)
+    await hass.async_block_till_done()
+    assert hass.states.get(dryer_switch).state == STATE_ON
+
+    freezer.tick(duration)
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     setup_humidity_sensor(hass, 60)
     await hass.async_block_till_done()

--- a/tests/test_dry_mode.py
+++ b/tests/test_dry_mode.py
@@ -57,7 +57,6 @@ from . import (  # noqa: F401
     setup_comp_1,
     setup_comp_heat_ac_cool,
     setup_comp_heat_ac_cool_cycle,
-    setup_comp_heat_ac_cool_cycle_kepp_alive,
     setup_comp_heat_ac_cool_fan_config,
     setup_comp_heat_ac_cool_presets,
     setup_comp_heat_ac_cool_safety_delay,
@@ -758,7 +757,7 @@ async def test_mode_change_ac_dry_trigger_off_not_long_enough(
     """Test if mode change turns dryer despite minimum cycle."""
     calls = setup_switch_dual(hass, common.ENT_DRYER, False, sw_on)
     await common.async_set_humidity(hass, 65)
-    setup_humidity_sensor(hass, 71 if sw_on else 50)
+    setup_humidity_sensor(hass, 50 if sw_on else 71)
     await hass.async_block_till_done()
     assert len(calls) == 0
     await common.async_set_hvac_mode(hass, HVACMode.OFF if sw_on else HVACMode.DRY)

--- a/tests/test_fan_mode.py
+++ b/tests/test_fan_mode.py
@@ -1,10 +1,8 @@
 """The tests for the dual_smart_thermostat."""
 
-import datetime
 from datetime import timedelta
 import logging
 
-from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 from homeassistant.components import input_boolean, input_number
 from homeassistant.components.climate import (
@@ -32,7 +30,6 @@ from homeassistant.core import DOMAIN as HASS_DOMAIN, HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt, dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
 import pytest
 
@@ -1059,563 +1056,327 @@ async def test_no_state_cooler_fan_change_when_operation_mode_off_2(
     assert len(calls) == 0
 
 
-async def test_temp_change_fan_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_temp_change_fan_trigger_long_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_fan_only_config_cycle,  # noqa: F811
 ) -> None:
-    """Test if temperature change turn fan on."""
-    calls = setup_switch(hass, False)
+    """Test if temperature change turn fan on or off."""
+    calls = setup_switch(hass, sw_on)
     await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
+    setup_sensor(hass, 30 if sw_on else 23)
     await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set temperature to switch
+    setup_sensor(hass, 23 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
     assert len(calls) == 0
 
-
-async def test_temp_change_cooler_fan_ac_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
+    # move back to no switch temp
+    setup_sensor(hass, 30 if sw_on else 23)
     await hass.async_block_till_done()
+
+    # go over cycle time
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # no call, not needed
     assert len(calls) == 0
 
-
-async def test_temp_change_cooler_fan_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
+    # set temperature to switch
+    setup_sensor(hass, 23 if sw_on else 30)
     await hass.async_block_till_done()
-    assert len(calls) == 0
 
-
-async def test_temp_change_fan_trigger_on_long_enough(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
+    # call triggered, time is enought and temp reached
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_SWITCH
 
 
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_time_change_fan_trigger_long_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_fan_only_config_cycle,  # noqa: F811
+) -> None:
+    """Test if temperature change turn fan on or off when cycle time is past."""
+    calls = setup_switch(hass, sw_on)
+    await common.async_set_temperature(hass, 25)
+    setup_sensor(hass, 30 if sw_on else 23)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set temperature to switch
+    setup_sensor(hass, 23 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
+    assert len(calls) == 0
+
+    # complete cycle time
+    freezer.tick(timedelta(minutes=5))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # call triggered, time is enought and temp reached
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == HASS_DOMAIN
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
+    assert call.data["entity_id"] == common.ENT_SWITCH
+
+
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_mode_change_fan_trigger_not_long_enough(
+    hass: HomeAssistant, sw_on, setup_comp_fan_only_config_cycle  # noqa: F811
+) -> None:
+    """Test if mode change turns fan despite minimum cycle."""
+    calls = setup_switch(hass, sw_on)
+    await common.async_set_temperature(hass, 25)
+    setup_sensor(hass, 30 if sw_on else 20)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    await common.async_set_hvac_mode(hass, HVACMode.OFF if sw_on else HVACMode.FAN_ONLY)
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == HASS_DOMAIN
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
+    assert call.data["entity_id"] == common.ENT_SWITCH
+
+
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_temp_change_cooler_fan_ac_trigger_on_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_heat_ac_cool_fan_config_cycle,  # noqa: F811
 ) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        await common.async_set_hvac_mode(hass, HVACMode.COOL)
-        calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
+    """Test if temperature change turn ac on or off."""
+    await common.async_set_hvac_mode(hass, HVACMode.COOL)
+    calls = setup_switch_dual(hass, common.ENT_FAN, sw_on, False)
     await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
+    setup_sensor(hass, 30 if sw_on else 23)
     await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set temperature to switch
+    setup_sensor(hass, 23 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
+    assert len(calls) == 0
+
+    # move back to no switch temp
+    setup_sensor(hass, 30 if sw_on else 23)
+    await hass.async_block_till_done()
+
+    # go over cycle time
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # no call, not needed
+    assert len(calls) == 0
+
+    # set temperature to switch
+    setup_sensor(hass, 23 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # call triggered, time is enought and temp reached
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_SWITCH
 
 
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_time_change_cooler_fan_ac_trigger_on_long_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_heat_ac_cool_fan_config_cycle,  # noqa: F811
+) -> None:
+    """Test if temperature change turn ac on or off when cycle time is past."""
+    await common.async_set_hvac_mode(hass, HVACMode.COOL)
+    calls = setup_switch_dual(hass, common.ENT_FAN, sw_on, False)
+    await common.async_set_temperature(hass, 25)
+    setup_sensor(hass, 30 if sw_on else 23)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set temperature to switch
+    setup_sensor(hass, 23 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
+    assert len(calls) == 0
+
+    # go over cycle time
+    freezer.tick(timedelta(minutes=5))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # call triggered, time is enought and temp reached
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == HASS_DOMAIN
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
+    assert call.data["entity_id"] == common.ENT_SWITCH
+
+
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_temp_change_cooler_fan_trigger_on_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_heat_ac_cool_fan_config_cycle,  # noqa: F811
 ) -> None:
-    """Test if temperature change turn fan on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-        calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_FAN
-
-
-async def test_temp_change_fan_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
-    calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_cooler_fan_ac_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    calls = setup_switch_dual(hass, common.ENT_FAN, True, False)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_cooler_fan_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
+    """Test if temperature change turn fan on or off."""
     await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
+    calls = setup_switch_dual(hass, common.ENT_FAN, False, sw_on)
+    await common.async_set_temperature(hass, 25)
+    setup_sensor(hass, 30 if sw_on else 23)
     await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set temperature to switch
+    setup_sensor(hass, 23 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
     assert len(calls) == 0
 
-
-async def test_temp_change_fan_trigger_off_long_enough(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
+    # move back to no switch temp
+    setup_sensor(hass, 30 if sw_on else 23)
     await hass.async_block_till_done()
+
+    # go over cycle time
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # no call, not needed
+    assert len(calls) == 0
+
+    # set temperature to switch
+    setup_sensor(hass, 23 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # call triggered, time is enought and temp reached
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_temp_change_cooler_fan_ac_trigger_off_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        await common.async_set_hvac_mode(hass, HVACMode.COOL)
-        calls = setup_switch_dual(hass, common.ENT_FAN, True, False)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_temp_change_cooler_fan_trigger_off_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-        calls = setup_switch_dual(hass, common.ENT_FAN, False, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_FAN
 
 
-async def test_mode_change_fan_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_time_change_cooler_fan_trigger_on_long_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sw_on,
+    setup_comp_heat_ac_cool_fan_config_cycle,  # noqa: F811
 ) -> None:
-    """Test if mode change turns fan off despite minimum cycle."""
-    calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
+    """Test if temperature change turn fan on or off when cycle time is past."""
+    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
+    calls = setup_switch_dual(hass, common.ENT_FAN, False, sw_on)
+    await common.async_set_temperature(hass, 25)
+    setup_sensor(hass, 30 if sw_on else 23)
     await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=6))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # set temperature to switch
+    setup_sensor(hass, 23 if sw_on else 30)
+    await hass.async_block_till_done()
+
+    # no call, not enought time
     assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
+
+    # go over cycle time
+    freezer.tick(timedelta(minutes=5))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # call triggered, time is enought and temp reached
     assert len(calls) == 1
     call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
+    assert call.domain == HASS_DOMAIN
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
+    assert call.data["entity_id"] == common.ENT_FAN
 
 
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_mode_change_cooler_fan_ac_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
+    hass: HomeAssistant, sw_on, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
 ) -> None:
-    """Test if mode change turns ac off despite minimum cycle."""
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    calls = setup_switch_dual(hass, common.ENT_FAN, True, False)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
+    """Test if mode change turns ac despite minimum cycle."""
+    await common.async_set_hvac_mode(hass, HVACMode.COOL if sw_on else HVACMode.OFF)
+    calls = setup_switch_dual(hass, common.ENT_FAN, sw_on, False)
+    await common.async_set_temperature(hass, 25)
+    setup_sensor(hass, 30 if sw_on else 20)
     await hass.async_block_till_done()
     assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
+    await common.async_set_hvac_mode(hass, HVACMode.OFF if sw_on else HVACMode.COOL)
     assert len(calls) == 1
     call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
+    assert call.domain == HASS_DOMAIN
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_SWITCH
 
 
+@pytest.mark.parametrize("sw_on", [True, False])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_mode_change_cooler_fan_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
+    hass: HomeAssistant, sw_on, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
 ) -> None:
-    """Test if mode change turns fan off despite minimum cycle."""
-    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
+    """Test if mode change turns fan despite minimum cycle."""
+    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY if sw_on else HVACMode.OFF)
+    calls = setup_switch_dual(hass, common.ENT_FAN, False, sw_on)
+    await common.async_set_temperature(hass, 25)
+    setup_sensor(hass, 30 if sw_on else 20)
     await hass.async_block_till_done()
     assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_FAN
-
-
-async def test_mode_change_fan_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns fan on despite minimum cycle."""
-    calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_mode_change_cooler_fan_ac_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac on despite minimum cycle."""
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_mode_change_cooler_fan_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns fan on despite minimum cycle."""
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_FAN
-
-
-async def test_temp_change_fan_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
-    calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_cooler_fan_ac_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_cooler_fan_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_fan_trigger_on_long_enough_2(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_hvac_mode(hass, HVACMode.OFF if sw_on else HVACMode.FAN_ONLY)
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_temp_change_cooler_fan_ac_trigger_on_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-        await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_temp_change_cooler_fan_trigger_on_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-        await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_FAN
-
-
-async def test_temp_change_fan_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
-    calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_cooler_fan_ac_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    calls = setup_switch_dual(hass, common.ENT_FAN, True, False)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_cooler_fan_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
-    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-async def test_temp_change_fan_trigger_off_long_enough_2(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_temp_change_cooler_fan_ac_trigger_off_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn ac on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        await common.async_set_hvac_mode(hass, HVACMode.COOL)
-        calls = setup_switch_dual(hass, common.ENT_FAN, True, False)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_temp_change_cooler_fan_trigger_off_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if temperature change turn fan on."""
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-        calls = setup_switch_dual(hass, common.ENT_FAN, False, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == HASS_DOMAIN
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_FAN
-
-
-async def test_mode_change_fan_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac off despite minimum cycle."""
-    calls = setup_switch(hass, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_mode_change_cooler_fan_ac_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac off despite minimum cycle."""
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    calls = setup_switch_dual(hass, common.ENT_FAN, True, False)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_mode_change_cooler_fan_trigger_off_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns fan off despite minimum cycle."""
-    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, True)
-    await common.async_set_temperature(hass, 30)
-    setup_sensor(hass, 25)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.OFF)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_OFF
-    assert call.data["entity_id"] == common.ENT_FAN
-
-
-async def test_mode_change_fan_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_fan_only_config_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns fan on despite minimum cycle."""
-    calls = setup_switch(hass, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_mode_change_cooler_fan_ac_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns ac on despite minimum cycle."""
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.COOL)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
-    assert call.data["entity_id"] == common.ENT_SWITCH
-
-
-async def test_mode_change_cooler_fan_trigger_on_not_long_enough_2(
-    hass: HomeAssistant, setup_comp_heat_ac_cool_fan_config_cycle  # noqa: F811
-) -> None:
-    """Test if mode change turns fan on despite minimum cycle."""
-    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
-    await common.async_set_temperature(hass, 25)
-    setup_sensor(hass, 30)
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == "homeassistant"
-    assert call.service == SERVICE_TURN_ON
+    assert call.service == SERVICE_TURN_OFF if sw_on else SERVICE_TURN_ON
     assert call.data["entity_id"] == common.ENT_FAN
 
 
@@ -2187,9 +1948,13 @@ async def test_cooler_fan_ac_and_mode(
         (timedelta(seconds=30), STATE_OFF),
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_fan_mode_cycle(
-    hass: HomeAssistant, duration, result_state, setup_comp_1  # noqa: F811
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    duration,
+    result_state,
+    setup_comp_1,  # noqa: F811
 ) -> None:
     """Test thermostat cooler switch in cooling mode with cycle duration."""
     cooler_switch = "input_boolean.test"
@@ -2229,11 +1994,13 @@ async def test_fan_mode_cycle(
     setup_sensor(hass, 23)
     await hass.async_block_till_done()
 
-    fake_changed = dt.utcnow() - duration
-    with freeze_time(fake_changed):
-        await common.async_set_temperature(hass, 18)
-        await hass.async_block_till_done()
-        assert hass.states.get(cooler_switch).state == STATE_ON
+    await common.async_set_temperature(hass, 18)
+    await hass.async_block_till_done()
+    assert hass.states.get(cooler_switch).state == STATE_ON
+
+    freezer.tick(duration)
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     setup_sensor(hass, 17)
     await hass.async_block_till_done()
@@ -2249,9 +2016,10 @@ async def test_fan_mode_cycle(
         (timedelta(seconds=30), HVACMode.FAN_ONLY, STATE_OFF, STATE_OFF),
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_cooler_fan_mode_cycle(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     duration,
     hvac_mode,
     cooler_result_state,
@@ -2299,21 +2067,22 @@ async def test_cooler_fan_mode_cycle(
     setup_sensor(hass, 23)
     await hass.async_block_till_done()
 
-    fake_changed = dt.utcnow() - duration
-    with freeze_time(fake_changed):
+    await common.async_set_temperature(hass, 18)
+    await hass.async_block_till_done()
+    assert (
+        hass.states.get(cooler_switch).state == STATE_ON
+        if hvac_mode == HVACMode.COOL
+        else STATE_OFF
+    )
+    assert (
+        hass.states.get(fan_switch).state == STATE_OFF
+        if hvac_mode == HVACMode.COOL
+        else STATE_ON
+    )
 
-        await common.async_set_temperature(hass, 18)
-        await hass.async_block_till_done()
-        assert (
-            hass.states.get(cooler_switch).state == STATE_ON
-            if hvac_mode == HVACMode.COOL
-            else STATE_OFF
-        )
-        assert (
-            hass.states.get(fan_switch).state == STATE_OFF
-            if hvac_mode == HVACMode.COOL
-            else STATE_ON
-        )
+    freezer.tick(duration)
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     setup_sensor(hass, 17)
     await hass.async_block_till_done()
@@ -2358,6 +2127,7 @@ async def test_set_target_temp_ac_fan_on(
     assert call.data["entity_id"] == common.ENT_FAN
 
 
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_set_target_temp_ac_on_tolerance_and_cycle(
     hass: HomeAssistant, setup_comp_1  # noqa: F811
 ) -> None:
@@ -2466,6 +2236,7 @@ async def test_set_target_temp_ac_on_after_fan_tolerance(
     assert call.data["entity_id"] == common.ENT_FAN
 
 
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_set_target_temp_ac_on_dont_switch_to_fan_during_cycle1(
     hass: HomeAssistant,
 ) -> None:
@@ -2499,6 +2270,7 @@ async def test_set_target_temp_ac_on_dont_switch_to_fan_during_cycle1(
     )
 
 
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_set_target_temp_ac_on_dont_switch_to_fan_during_cycle2(
     hass: HomeAssistant,
 ) -> None:
@@ -2518,16 +2290,19 @@ async def test_set_target_temp_ac_on_dont_switch_to_fan_during_cycle2(
     assert len(calls) == 0
 
 
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_set_target_temp_ac_on_dont_switch_to_fan_during_cycle3(
-    hass: HomeAssistant,
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test if switched to fan because min_cycle_duration reached."""
     # Given
     await setup_comp_heat_ac_cool_fan_config_tolerance_min_cycle(hass)
 
-    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
-    with freeze_time(fake_changed):
-        calls = setup_switch_dual(hass, common.ENT_FAN, True, False)
+    calls = setup_switch_dual(hass, common.ENT_FAN, True, False)
+
+    freezer.tick(timedelta(minutes=3))
+    common.async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     # When
     await common.async_set_hvac_mode(hass, HVACMode.COOL)
@@ -3108,10 +2883,6 @@ async def test_fan_mode_opening_hvac_action_reason(
     )
 
     # wait 5 seconds
-    # common.async_fire_time_changed(
-    #     hass, dt_util.utcnow() + datetime.timedelta(minutes=10)
-    # )
-    # await asyncio.sleep(5)
     freezer.tick(timedelta(seconds=6))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -3248,10 +3019,6 @@ async def test_cooler_fan_mode_opening_hvac_action_reason(
     )
 
     # wait 5 seconds
-    # common.async_fire_time_changed(
-    #     hass, dt_util.utcnow() + datetime.timedelta(minutes=10)
-    # )
-    # await asyncio.sleep(5)
     freezer.tick(timedelta(seconds=6))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -3358,10 +3125,6 @@ async def test_fan_mode_opening(
     assert hass.states.get(cooler_switch).state == STATE_ON
 
     # wait 5 seconds
-    # common.async_fire_time_changed(
-    #     hass, dt_util.utcnow() + datetime.timedelta(minutes=10)
-    # )
-    # await asyncio.sleep(5)
     freezer.tick(timedelta(seconds=6))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -3503,10 +3266,6 @@ async def test_cooler_fan_mode_opening(
     )
 
     # wait 5 seconds
-    # common.async_fire_time_changed(
-    #     hass, dt_util.utcnow() + datetime.timedelta(minutes=10)
-    # )
-    # await asyncio.sleep(5)
     freezer.tick(timedelta(seconds=6))
     common.async_fire_time_changed(hass)
     await hass.async_block_till_done()


### PR DESCRIPTION
Scope of this PR is fix the 2 options  `min-cycle-duration` and `keep-alive` that is not working properly.

- **min-cycle-duration**: this option is time based, because should guaranty that the device maintain the state at least the time specified. But because the change of the state is only triggered by integration on event (temp change, humidity change, etc..) it could happen that after the min cycle period the event is not triggered anymore and the controlled device remain in the current state for very long time. To solve this in case of `min-cycle-duration` configured I added a scheduled check (every minute) to verify if the period is over.

- **keep-alive**: this option must force the command to the device also in case that the status of the related switch is correct, because some device can loose the information for real status. Because there was a check at very lower level to avoid send command to the switch when the status is what expected, `keep-alive` doesn't work at all. Now I removed low level check and I added checks where required, to avoid not requested forced command. Based on tests result and my local run every think seems work properly.

**N.B**.` keep-alive` and `min-cycle-duration` are 2 options incompatible because keep alive will force status change also when the min-cycle value is not reached. For this reason when `keep-live` is specified `min-cycle-duration` option is ignored. I added this information in `read-me` to avoid confusion (in original [generic-thermostat](https://www.home-assistant.io/integrations/generic_thermostat/) integration they have same logic and same warning).

I also changed some logs from info to debug level because this integration was really logging a lot of information....

Of course I review all tests, especially to properly check `min-cycle-duration` condition (probably I spend most of the time in test review 😉)