### PR TITLE
Use relative path for integration modules import

### DIFF
--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -55,33 +55,6 @@ from homeassistant.helpers.service import extract_entity_ids
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import voluptuous as vol
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason_external import (
-    HVACActionReasonExternal,
-)
-from custom_components.dual_smart_thermostat.hvac_device.controllable_hvac_device import (
-    ControlableHVACDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.hvac_device_factory import (
-    HVACDeviceFactory,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-    TargetTemperatures,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.hvac_power_manager import (
-    HvacPowerManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningHvacModeScope,
-    OpeningManager,
-)
-from custom_components.dual_smart_thermostat.managers.preset_manager import (
-    PresetManager,
-)
-
 from . import DOMAIN, PLATFORMS
 from .const import (
     ATTR_CLOSING_TIMEOUT,
@@ -151,6 +124,15 @@ from .hvac_action_reason.hvac_action_reason import (
     SET_HVAC_ACTION_REASON_SIGNAL,
     HVACActionReason,
 )
+from .hvac_action_reason.hvac_action_reason_external import HVACActionReasonExternal
+from .hvac_device.controllable_hvac_device import ControlableHVACDevice
+from .hvac_device.hvac_device_factory import HVACDeviceFactory
+from .managers.environment_manager import EnvironmentManager, TargetTemperatures
+from .managers.feature_manager import FeatureManager
+from .managers.hvac_power_manager import HvacPowerManager
+from .managers.opening_manager import OpeningHvacModeScope, OpeningManager
+from .managers.preset_manager import PresetManager
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_action_reason/hvac_action_reason.py
+++ b/custom_components/dual_smart_thermostat/hvac_action_reason/hvac_action_reason.py
@@ -1,12 +1,8 @@
 import enum
 from itertools import chain
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason_external import (
-    HVACActionReasonExternal,
-)
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason_internal import (
-    HVACActionReasonInternal,
-)
+from ..hvac_action_reason.hvac_action_reason_external import HVACActionReasonExternal
+from ..hvac_action_reason.hvac_action_reason_internal import HVACActionReasonInternal
 
 SET_HVAC_ACTION_REASON_SIGNAL = "set_hvac_action_reason_signal_{}"
 SERVICE_SET_HVAC_ACTION_REASON = "set_hvac_action_reason"

--- a/custom_components/dual_smart_thermostat/hvac_controller/cooler_controller.py
+++ b/custom_components/dual_smart_thermostat/hvac_controller/cooler_controller.py
@@ -4,15 +4,9 @@ from typing import Callable
 
 from homeassistant.core import HomeAssistant
 
-from custom_components.dual_smart_thermostat.hvac_controller.generic_controller import (
-    GenericHvacController,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_controller.generic_controller import GenericHvacController
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
+++ b/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
@@ -10,19 +10,11 @@ from homeassistant.exceptions import ConditionError
 from homeassistant.helpers import condition
 import homeassistant.util.dt as dt_util
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.hvac_controller import (
-    HvacController,
-    HvacEnvStrategy,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..hvac_controller.hvac_controller import HvacController, HvacEnvStrategy
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.opening_manager import OpeningManager
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_controller/heater_controller.py
+++ b/custom_components/dual_smart_thermostat/hvac_controller/heater_controller.py
@@ -4,21 +4,11 @@ from typing import Callable
 
 from homeassistant.core import HomeAssistant
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.generic_controller import (
-    GenericHvacController,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.hvac_controller import (
-    HvacEnvStrategy,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..hvac_controller.generic_controller import GenericHvacController
+from ..hvac_controller.hvac_controller import HvacEnvStrategy
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_controller/hvac_controller.py
+++ b/custom_components/dual_smart_thermostat/hvac_controller/hvac_controller.py
@@ -7,15 +7,9 @@ from typing import Callable
 from homeassistant.components.climate import HVACMode
 from homeassistant.core import HomeAssistant
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
@@ -4,12 +4,8 @@ import logging
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, State, callback
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    TargetTemperatures,
-)
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..managers.environment_manager import TargetTemperatures
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/cooler_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/cooler_device.py
@@ -4,27 +4,15 @@ import logging
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.core import HomeAssistant
 
-from custom_components.dual_smart_thermostat.hvac_controller.cooler_controller import (
-    CoolerHvacController,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.hvac_controller import (
-    HvacGoal,
-)
-from custom_components.dual_smart_thermostat.hvac_device.generic_hvac_device import (
-    GenericHVACDevice,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
+from ..hvac_controller.cooler_controller import CoolerHvacController
+from ..hvac_controller.hvac_controller import HvacGoal
+from ..hvac_device.generic_hvac_device import GenericHVACDevice
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import (
     FeatureManager,
 )
-from custom_components.dual_smart_thermostat.managers.hvac_power_manager import (
-    HvacPowerManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..managers.hvac_power_manager import HvacPowerManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
@@ -7,24 +7,12 @@ from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant
 from homeassistant.helpers.event import async_track_state_change_event
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.hvac_device.generic_hvac_device import (
-    GenericHVACDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.multi_hvac_device import (
-    MultiHvacDevice,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..hvac_device.generic_hvac_device import GenericHVACDevice
+from ..hvac_device.multi_hvac_device import MultiHvacDevice
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/dryer_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/dryer_device.py
@@ -4,27 +4,13 @@ import logging
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.core import HomeAssistant
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.hvac_controller import (
-    HvacGoal,
-)
-from custom_components.dual_smart_thermostat.hvac_device.generic_hvac_device import (
-    GenericHVACDevice,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.hvac_power_manager import (
-    HvacPowerManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..hvac_controller.hvac_controller import HvacGoal
+from ..hvac_device.generic_hvac_device import GenericHVACDevice
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.hvac_power_manager import HvacPowerManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/fan_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/fan_device.py
@@ -4,21 +4,11 @@ import logging
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.core import HomeAssistant
 
-from custom_components.dual_smart_thermostat.hvac_device.cooler_device import (
-    CoolerDevice,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.hvac_power_manager import (
-    HvacPowerManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_device.cooler_device import CoolerDevice
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.hvac_power_manager import HvacPowerManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
@@ -19,37 +19,19 @@ from homeassistant.const import (
 )
 from homeassistant.core import DOMAIN as HA_DOMAIN, Context, HomeAssistant
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.generic_controller import (
-    GenericHvacController,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.hvac_controller import (
-    HvacController,
-    HvacEnvStrategy,
-    HvacGoal,
-)
-from custom_components.dual_smart_thermostat.hvac_device.controllable_hvac_device import (
-    ControlableHVACDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.hvac_device import (
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..hvac_controller.generic_controller import GenericHvacController
+from ..hvac_controller.hvac_controller import HvacController, HvacEnvStrategy, HvacGoal
+from ..hvac_device.controllable_hvac_device import ControlableHVACDevice
+from ..hvac_device.hvac_device import (
     HVACDevice,
     Switchable,
     TargetsEnvironmentAttribute,
 )
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.hvac_power_manager import (
-    HvacPowerManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.hvac_power_manager import HvacPowerManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/heat_pump_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/heat_pump_device.py
@@ -5,35 +5,15 @@ from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State, callback
 
-from custom_components.dual_smart_thermostat.hvac_controller.cooler_controller import (
-    CoolerHvacController,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.heater_controller import (
-    HeaterHvacConroller,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.hvac_controller import (
-    HvacEnvStrategy,
-    HvacGoal,
-)
-from custom_components.dual_smart_thermostat.hvac_device.generic_hvac_device import (
-    GenericHVACDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.hvac_device import (
-    merge_hvac_modes,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-    TargetTemperatures,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.hvac_power_manager import (
-    HvacPowerManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_controller.cooler_controller import CoolerHvacController
+from ..hvac_controller.heater_controller import HeaterHvacConroller
+from ..hvac_controller.hvac_controller import HvacEnvStrategy, HvacGoal
+from ..hvac_device.generic_hvac_device import GenericHVACDevice
+from ..hvac_device.hvac_device import merge_hvac_modes
+from ..managers.environment_manager import EnvironmentManager, TargetTemperatures
+from ..managers.feature_manager import FeatureManager
+from ..managers.hvac_power_manager import HvacPowerManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/heater_aux_heater_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/heater_aux_heater_device.py
@@ -9,21 +9,11 @@ from homeassistant.helpers import condition
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.hvac_device.multi_hvac_device import (
-    MultiHvacDevice,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..hvac_device.multi_hvac_device import MultiHvacDevice
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/heater_cooler_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/heater_cooler_device.py
@@ -3,25 +3,13 @@ import logging
 from homeassistant.components.climate import HVACMode
 from homeassistant.core import HomeAssistant
 
-from custom_components.dual_smart_thermostat.const import ToleranceDevice
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.hvac_device.hvac_device import (
-    merge_hvac_modes,
-)
-from custom_components.dual_smart_thermostat.hvac_device.multi_hvac_device import (
-    MultiHvacDevice,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..const import ToleranceDevice
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..hvac_device.hvac_device import merge_hvac_modes
+from ..hvac_device.multi_hvac_device import MultiHvacDevice
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/heater_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/heater_device.py
@@ -4,27 +4,13 @@ import logging
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.core import HomeAssistant
 
-from custom_components.dual_smart_thermostat.hvac_controller.heater_controller import (
-    HeaterHvacConroller,
-)
-from custom_components.dual_smart_thermostat.hvac_controller.hvac_controller import (
-    HvacGoal,
-)
-from custom_components.dual_smart_thermostat.hvac_device.generic_hvac_device import (
-    GenericHVACDevice,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.hvac_power_manager import (
-    HvacPowerManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_controller.heater_controller import HeaterHvacConroller
+from ..hvac_controller.hvac_controller import HvacGoal
+from ..hvac_device.generic_hvac_device import GenericHVACDevice
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.hvac_power_manager import HvacPowerManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/hvac_device.py
@@ -5,15 +5,9 @@ from typing import Self
 from homeassistant.components.climate import HVACMode
 from homeassistant.core import Context, HomeAssistant
 
-from custom_components.dual_smart_thermostat.hvac_controller.hvac_controller import (
-    HvacGoal,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_controller.hvac_controller import HvacGoal
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/hvac_device_factory.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/hvac_device_factory.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from custom_components.dual_smart_thermostat.const import (
+from ..const import (
     CONF_AUX_HEATER,
     CONF_AUX_HEATING_DUAL_MODE,
     CONF_AUX_HEATING_TIMEOUT,
@@ -17,44 +17,20 @@ from custom_components.dual_smart_thermostat.const import (
     CONF_INITIAL_HVAC_MODE,
     CONF_MIN_DUR,
 )
-from custom_components.dual_smart_thermostat.hvac_device.controllable_hvac_device import (
-    ControlableHVACDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.cooler_device import (
-    CoolerDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.cooler_fan_device import (
-    CoolerFanDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.dryer_device import DryerDevice
-from custom_components.dual_smart_thermostat.hvac_device.fan_device import FanDevice
-from custom_components.dual_smart_thermostat.hvac_device.heat_pump_device import (
-    HeatPumpDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.heater_aux_heater_device import (
-    HeaterAUXHeaterDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.heater_cooler_device import (
-    HeaterCoolerDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.heater_device import (
-    HeaterDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.multi_hvac_device import (
-    MultiHvacDevice,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.hvac_power_manager import (
-    HvacPowerManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_device.controllable_hvac_device import ControlableHVACDevice
+from ..hvac_device.cooler_device import CoolerDevice
+from ..hvac_device.cooler_fan_device import CoolerFanDevice
+from ..hvac_device.dryer_device import DryerDevice
+from ..hvac_device.fan_device import FanDevice
+from ..hvac_device.heat_pump_device import HeatPumpDevice
+from ..hvac_device.heater_aux_heater_device import HeaterAUXHeaterDevice
+from ..hvac_device.heater_cooler_device import HeaterCoolerDevice
+from ..hvac_device.heater_device import HeaterDevice
+from ..hvac_device.multi_hvac_device import MultiHvacDevice
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.hvac_power_manager import HvacPowerManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
@@ -4,22 +4,12 @@ from typing import Callable
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.core import Context, HomeAssistant, callback
 
-from custom_components.dual_smart_thermostat.hvac_action_reason.hvac_action_reason import (
-    HVACActionReason,
-)
-from custom_components.dual_smart_thermostat.hvac_device.controllable_hvac_device import (
-    ControlableHVACDevice,
-)
-from custom_components.dual_smart_thermostat.hvac_device.hvac_device import HVACDevice
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.opening_manager import (
-    OpeningManager,
-)
+from ..hvac_action_reason.hvac_action_reason import HVACActionReason
+from ..hvac_device.controllable_hvac_device import ControlableHVACDevice
+from ..hvac_device.hvac_device import HVACDevice
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.opening_manager import OpeningManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.unit_conversion import TemperatureConverter
 
-from custom_components.dual_smart_thermostat.const import (
+from ..const import (
     ATTR_PREV_TARGET,
     ATTR_PREV_TARGET_HIGH,
     ATTR_PREV_TARGET_LOW,
@@ -44,8 +44,8 @@ from custom_components.dual_smart_thermostat.const import (
     CONF_TEMP_STEP,
     DEFAULT_MAX_FLOOR_TEMP,
 )
-from custom_components.dual_smart_thermostat.managers.state_manager import StateManager
-from custom_components.dual_smart_thermostat.preset_env.preset_env import PresetEnv
+from ..managers.state_manager import StateManager
+from ..preset_env.preset_env import PresetEnv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/managers/feature_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/feature_manager.py
@@ -9,7 +9,7 @@ from homeassistant.const import ATTR_SUPPORTED_FEATURES
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.typing import ConfigType
 
-from custom_components.dual_smart_thermostat.const import (
+from ..const import (
     CONF_AC_MODE,
     CONF_AUX_HEATER,
     CONF_AUX_HEATING_DUAL_MODE,
@@ -29,11 +29,9 @@ from custom_components.dual_smart_thermostat.const import (
     CONF_HVAC_POWER_LEVELS,
     CONF_HVAC_POWER_TOLERANCE,
 )
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.state_manager import StateManager
-from custom_components.dual_smart_thermostat.preset_env.preset_env import PresetEnv
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.state_manager import StateManager
+from ..preset_env.preset_env import PresetEnv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/managers/hvac_power_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/hvac_power_manager.py
@@ -5,19 +5,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
-from custom_components.dual_smart_thermostat.const import (
+from ..const import (
     CONF_HVAC_POWER_LEVELS,
     CONF_HVAC_POWER_MAX,
     CONF_HVAC_POWER_MIN,
     CONF_HVAC_POWER_TOLERANCE,
 )
-from custom_components.dual_smart_thermostat.hvac_controller.hvac_controller import (
-    HvacEnvStrategy,
-)
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentAttributeType,
-    EnvironmentManager,
-)
+from ..hvac_controller.hvac_controller import HvacEnvStrategy
+from ..managers.environment_manager import EnvironmentAttributeType, EnvironmentManager
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/managers/opening_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/opening_manager.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import condition
 from homeassistant.helpers.typing import ConfigType
 
-from custom_components.dual_smart_thermostat.const import (
+from ..const import (
     ATTR_CLOSING_TIMEOUT,
     ATTR_OPENING_TIMEOUT,
     CONF_OPENINGS,

--- a/custom_components/dual_smart_thermostat/managers/preset_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/preset_manager.py
@@ -10,15 +10,11 @@ from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import State
 from homeassistant.helpers.typing import ConfigType
 
-from custom_components.dual_smart_thermostat.const import CONF_PRESETS, CONF_PRESETS_OLD
-from custom_components.dual_smart_thermostat.managers.environment_manager import (
-    EnvironmentManager,
-)
-from custom_components.dual_smart_thermostat.managers.feature_manager import (
-    FeatureManager,
-)
-from custom_components.dual_smart_thermostat.managers.state_manager import StateManager
-from custom_components.dual_smart_thermostat.preset_env.preset_env import PresetEnv
+from ..const import CONF_PRESETS, CONF_PRESETS_OLD
+from ..managers.environment_manager import EnvironmentManager
+from ..managers.feature_manager import FeatureManager
+from ..managers.state_manager import StateManager
+from ..preset_env.preset_env import PresetEnv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dual_smart_thermostat/preset_env/preset_env.py
+++ b/custom_components/dual_smart_thermostat/preset_env/preset_env.py
@@ -7,10 +7,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import ATTR_TEMPERATURE
 
-from custom_components.dual_smart_thermostat.const import (
-    CONF_MAX_FLOOR_TEMP,
-    CONF_MIN_FLOOR_TEMP,
-)
+from ..const import CONF_MAX_FLOOR_TEMP, CONF_MIN_FLOOR_TEMP
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
This is only a cosmetic change, don't be afraid 😉.
Just remove long path `custom_components.dual_smart_thermostat` on import clause and replace with relative path.