### PR TITLE
Fix critical options flow persistence bug and add E2E tests

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git commit -m \"$(cat <<''EOF''\nFix critical options flow persistence bug and add E2E tests\n\n- Fix options flow not persisting changes (was only reading entry.data, not entry.options)\n- Add _get_current_config() to merge data+options with mappingproxy handling\n- Strip transient flags from storage with _clean_config_for_storage()\n- Fix feature toggles to check actual config state instead of transient flags\n- Add E2E persistence tests for heater_cooler, simple_heater, ac_only system types\n\nTests: 78 passing (4 new E2E tests)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\")"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/DEBUG_FAN_PERSISTENCE.md
+++ b/DEBUG_FAN_PERSISTENCE.md
@@ -1,0 +1,160 @@
+# Debug Logging for Fan Settings Persistence Issue
+
+This document explains how to enable debug logging to diagnose the fan settings persistence issue you're experiencing in the UI.
+
+## What Was Added
+
+Debug logging has been added to track fan settings throughout the config and options flows:
+
+1. **`feature_steps/fan.py`**:
+   - Logs when fan config/options form is shown (with current defaults)
+   - Logs user input when form is submitted
+   - Logs collected_config before and after update
+
+2. **`schemas.py`**:
+   - Logs the defaults passed to `get_fan_schema()`
+   - Shows what values should be pre-filled in the UI
+
+3. **`options_flow.py`**:
+   - Logs fan settings from existing config entry
+   - Logs fan settings in collected_config
+   - Logs final merged data before saving
+
+## How to Enable Debug Logging
+
+### Method 1: Via Home Assistant UI (Recommended)
+
+1. Go to **Settings** → **System** → **Logs**
+2. Click **"Configure"** (top right)
+3. Add these log filters:
+   ```
+   custom_components.dual_smart_thermostat.feature_steps.fan: debug
+   custom_components.dual_smart_thermostat.schemas: debug
+   custom_components.dual_smart_thermostat.options_flow: debug
+   ```
+4. Click **Save**
+
+### Method 2: Via configuration.yaml
+
+Add to your `configuration.yaml`:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.dual_smart_thermostat.feature_steps.fan: debug
+    custom_components.dual_smart_thermostat.schemas: debug
+    custom_components.dual_smart_thermostat.options_flow: debug
+```
+
+Then restart Home Assistant.
+
+## How to Reproduce and Capture Logs
+
+1. **Enable logging** (using Method 1 or 2 above)
+
+2. **Clear existing logs** (optional but recommended):
+   - Settings → System → Logs → Click "Clear" button
+
+3. **Reproduce the issue**:
+   - Open your thermostat integration
+   - Click "Configure"
+   - Navigate through the flow to fan settings
+   - Toggle "Fan on with AC" to OFF (or whichever setting is not persisting)
+   - Complete the flow
+
+4. **Reopen options flow**:
+   - Click "Configure" again
+   - Navigate to fan settings
+   - Observe if the setting reverted
+
+5. **View logs**:
+   - Settings → System → Logs
+   - Look for lines containing "Fan options", "get_fan_schema", or "Options flow completion"
+
+## What to Look For in Logs
+
+### When Showing Fan Options Form
+
+You should see:
+```
+Fan options - Showing form with current_config defaults: fan=switch.fan, fan_mode=False, fan_on_with_ac=False, fan_air_outside=False
+get_fan_schema called with defaults: fan=switch.fan, fan_mode=False, fan_on_with_ac=False, fan_air_outside=False
+```
+
+**Check**: Do the defaults match what you saved? If `fan_on_with_ac=True` here but you set it to False, the config wasn't saved.
+
+### When Submitting Fan Options
+
+You should see:
+```
+Fan options - user_input received: {'fan': 'switch.fan', 'fan_mode': False, 'fan_on_with_ac': False}
+Fan options - collected_config before update: fan_mode=None, fan_on_with_ac=None
+Fan options - collected_config after update: fan_mode=False, fan_on_with_ac=False
+```
+
+**Check**: Is the setting you changed in `user_input`? If not, the UI didn't send it (voluptuous Optional field issue).
+
+### At Flow Completion
+
+You should see:
+```
+Options flow completion - entry.data fan settings: fan=switch.fan, fan_mode=False, fan_on_with_ac=True
+Options flow completion - collected_config fan settings: fan=switch.fan, fan_mode=None, fan_on_with_ac=None
+Options flow completion - updated_data fan settings: fan=switch.fan, fan_mode=False, fan_on_with_ac=True
+```
+
+**Check**: Does `updated_data` have the correct values? This is what gets saved.
+
+## Expected Behavior vs Bug
+
+### Expected (Working Correctly)
+
+1. Form shows: `fan_on_with_ac=True` (from config)
+2. User changes to: `False`
+3. user_input contains: `{'fan_on_with_ac': False}`
+4. collected_config updated: `fan_on_with_ac=False`
+5. updated_data contains: `fan_on_with_ac=False`
+6. Next time form shows: `fan_on_with_ac=False` ✅
+
+### Bug Scenario A: Value Not in user_input
+
+1. Form shows: `fan_on_with_ac=True` (from config)
+2. User changes to: `False`
+3. user_input MISSING: `{}` or doesn't contain `fan_on_with_ac` ❌
+4. collected_config not updated: `fan_on_with_ac=None`
+5. updated_data preserves old: `fan_on_with_ac=True`
+6. Next time form shows: `fan_on_with_ac=True` (reverted)
+
+### Bug Scenario B: Value Not in Config
+
+1. Form shows: `fan_on_with_ac=True` (default, not from config)
+2. User changes to: `False`
+3. user_input contains: `{'fan_on_with_ac': False}`
+4. collected_config updated: `fan_on_with_ac=False`
+5. But entry.data doesn't have it, so merge loses it ❌
+6. Next time form shows: `fan_on_with_ac=True` (default)
+
+## Sharing Logs
+
+After reproducing the issue:
+
+1. Go to Settings → System → Logs
+2. Click the "Download" button
+3. Share the `home-assistant.log` file or copy relevant lines
+
+Look for lines containing:
+- `Fan options -`
+- `Fan config -`
+- `get_fan_schema`
+- `Options flow completion -`
+
+## Next Steps
+
+Once you've captured the logs, we can determine:
+1. Is the value being sent from UI? (check `user_input`)
+2. Is it being saved to collected_config? (check `after update`)
+3. Is it in the final config entry? (check `updated_data`)
+4. Is it being loaded back? (check `current_config defaults`)
+
+This will pinpoint exactly where the value is being lost!

--- a/README.md
+++ b/README.md
@@ -455,18 +455,30 @@ The internal values can be set by the component only and the external values can
 
 ### fan_hot_tolerance
 
-  _(optional) (float)_ Set a maximum amount of difference between the temperature read by the sensor specified in the _target_sensor_ option and the target temperature and the _hot_tolerance_ that considered to be ok for the fan to be turned on. For example, if the target temperature is 25 and the hot_tolerance is 1 and the fan_hot_tolerance is 0.5 the fan will start when the sensor equals or goes above 25 but not above 25.5. In that case the AC will turn on.
+  _(optional) (float)_ Temperature range above `hot_tolerance` where the fan is used instead of the AC. This creates an intermediate zone where the fan attempts to cool before engaging the AC.
+
+  **Example:** With target temperature 25°C, `hot_tolerance` 1°C, and `fan_hot_tolerance` 0.5°C:
+  - At 26°C (target + hot_tolerance): Fan turns on
+  - At 26.5°C (target + hot_tolerance + fan_hot_tolerance): AC turns on (fan turns off)
+
+  This feature helps save energy by using the fan for minor temperature increases before engaging the more power-intensive AC.
+
+  _default: 0.5_
 
   _requires: `fan`_
 
 ### fan_hot_tolerance_toggle
 
-  _(optional) (string)_ `entity_id` for a switch that will toggle the `fan_hot_tolerance` feature on and off.
-  This is enabled by default.
+  _(optional) (string)_ `entity_id` for an `input_boolean` or `binary_sensor` that dynamically enables/disables the `fan_hot_tolerance` feature.
 
-  _default: True_
+  - When the toggle entity is `on` (or not configured): The fan_hot_tolerance feature is active
+  - When the toggle entity is `off`: The AC is used immediately when `hot_tolerance` is exceeded (bypasses fan zone)
 
-  _requires: `fan` , `fan_hot_tolerance`_
+  Useful for automations that disable fan-first behavior during extreme heat, high humidity, or other conditions where immediate AC is preferred.
+
+  _default: Feature enabled (behaves as if toggle is `on`)_
+
+  _requires: `fan`_
 
 ### fan_on_with_ac
 

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -585,8 +585,11 @@ climate:
   #   precision: 0.1
 
 logger:
-  default: error
+  default: info
   logs:
     custom_components.dual_smart_thermostat: debug
+    custom_components.dual_smart_thermostat.feature_steps.fan: debug
+    custom_components.dual_smart_thermostat.schemas: debug
+    custom_components.dual_smart_thermostat.options_flow: debug
 
 # debugpy:

--- a/custom_components/dual_smart_thermostat/feature_steps/fan.py
+++ b/custom_components/dual_smart_thermostat/feature_steps/fan.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import selector
-import voluptuous as vol
 
 from ..const import CONF_FAN, CONF_FAN_AIR_OUTSIDE, CONF_FAN_MODE, CONF_FAN_ON_WITH_AC
 from ..schemas import get_fan_schema, get_fan_toggle_schema
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class FanSteps:
@@ -45,10 +46,20 @@ class FanSteps:
     ) -> FlowResult:
         """Handle fan configuration."""
         if user_input is not None:
+            _LOGGER.debug(
+                "Fan config - user_input received: %s",
+                {k: v for k, v in user_input.items() if k.startswith("fan")},
+            )
             collected_config.update(user_input)
+            _LOGGER.debug(
+                "Fan config - collected_config after update: fan_mode=%s, fan_on_with_ac=%s",
+                collected_config.get(CONF_FAN_MODE),
+                collected_config.get(CONF_FAN_ON_WITH_AC),
+            )
             return await next_step_handler()
 
         # Use the shared context in case schema factories need hass/current values
+        _LOGGER.debug("Fan config - Showing form with no defaults (new config)")
         return flow_instance.async_show_form(
             step_id="fan",
             data_schema=get_fan_schema(),
@@ -64,34 +75,32 @@ class FanSteps:
     ) -> FlowResult:
         """Handle fan options (for options flow)."""
         if user_input is not None:
+            _LOGGER.debug(
+                "Fan options - user_input received: %s",
+                {k: v for k, v in user_input.items() if k.startswith("fan")},
+            )
+            _LOGGER.debug(
+                "Fan options - collected_config before update: fan_mode=%s, fan_on_with_ac=%s",
+                collected_config.get(CONF_FAN_MODE),
+                collected_config.get(CONF_FAN_ON_WITH_AC),
+            )
             collected_config.update(user_input)
+            _LOGGER.debug(
+                "Fan options - collected_config after update: fan_mode=%s, fan_on_with_ac=%s",
+                collected_config.get(CONF_FAN_MODE),
+                collected_config.get(CONF_FAN_ON_WITH_AC),
+            )
             return await next_step_handler()
 
-        schema_dict = {}
-
-        # Always show fan entity selector
-        schema_dict[vol.Optional(CONF_FAN, default=current_config.get(CONF_FAN))] = (
-            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch"))
+        # Use the unified schema with current config as defaults
+        _LOGGER.debug(
+            "Fan options - Showing form with current_config defaults: fan=%s, fan_mode=%s, fan_on_with_ac=%s, fan_air_outside=%s",
+            current_config.get(CONF_FAN),
+            current_config.get(CONF_FAN_MODE),
+            current_config.get(CONF_FAN_ON_WITH_AC),
+            current_config.get(CONF_FAN_AIR_OUTSIDE),
         )
-
-        # Always show fan configuration options
-        schema_dict.update(
-            {
-                vol.Optional(
-                    CONF_FAN_MODE, default=current_config.get(CONF_FAN_MODE, False)
-                ): selector.BooleanSelector(),
-                vol.Optional(
-                    CONF_FAN_ON_WITH_AC,
-                    default=current_config.get(CONF_FAN_ON_WITH_AC, False),
-                ): selector.BooleanSelector(),
-                vol.Optional(
-                    CONF_FAN_AIR_OUTSIDE,
-                    default=current_config.get(CONF_FAN_AIR_OUTSIDE, False),
-                ): selector.BooleanSelector(),
-            }
-        )
-
         return flow_instance.async_show_form(
             step_id="fan_options",
-            data_schema=vol.Schema(schema_dict),
+            data_schema=get_fan_schema(defaults=current_config),
         )

--- a/custom_components/dual_smart_thermostat/feature_steps/humidity.py
+++ b/custom_components/dual_smart_thermostat/feature_steps/humidity.py
@@ -4,21 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import selector
-import voluptuous as vol
 
-from ..const import (
-    CONF_DRY_TOLERANCE,
-    CONF_DRYER,
-    CONF_HUMIDITY_SENSOR,
-    CONF_MAX_HUMIDITY,
-    CONF_MIN_HUMIDITY,
-    CONF_MOIST_TOLERANCE,
-    CONF_TARGET_HUMIDITY,
-)
-from ..schema_utils import get_entity_selector
 from ..schemas import get_humidity_schema, get_humidity_toggle_schema
 
 
@@ -77,86 +64,8 @@ class HumiditySteps:
             collected_config.update(user_input)
             return await next_step_handler()
 
-        schema_dict = {}
-
-        # Always show humidity sensor option
-        # Use the shared entity selector helper to ensure consistent
-        # domain-only selector behavior. Using the specific
-        # `device_class` filter can prevent some sensors from appearing
-        # in the frontend selector; the integration prefers domain-only
-        # filtering for broader compatibility in options flow.
-        schema_dict[
-            vol.Optional(
-                CONF_HUMIDITY_SENSOR,
-                default=current_config.get(CONF_HUMIDITY_SENSOR),
-            )
-        ] = get_entity_selector(SENSOR_DOMAIN)
-
-        # Always show dryer option
-        schema_dict[
-            vol.Optional(CONF_DRYER, default=current_config.get(CONF_DRYER))
-        ] = selector.EntitySelector(selector.EntitySelectorConfig(domain="switch"))
-
-        # Always show all humidity configuration fields
-        # Use current_config value if present, otherwise fall back to the same
-        # defaults used by the config flow schema so options forms are pre-filled
-        # consistently.
-        schema_dict[
-            vol.Optional(
-                CONF_TARGET_HUMIDITY,
-                default=current_config.get(CONF_TARGET_HUMIDITY, 50),
-            )
-        ] = selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                mode=selector.NumberSelectorMode.BOX,
-                unit_of_measurement="%",
-                min=0,
-                max=100,
-            )
-        )
-
-        schema_dict[
-            vol.Optional(
-                CONF_MIN_HUMIDITY, default=current_config.get(CONF_MIN_HUMIDITY, 30)
-            )
-        ] = selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                mode=selector.NumberSelectorMode.BOX,
-                unit_of_measurement="%",
-                min=0,
-                max=100,
-            )
-        )
-
-        schema_dict[
-            vol.Optional(
-                CONF_MAX_HUMIDITY, default=current_config.get(CONF_MAX_HUMIDITY, 99)
-            )
-        ] = selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                mode=selector.NumberSelectorMode.BOX,
-                unit_of_measurement="%",
-                min=0,
-                max=100,
-            )
-        )
-
-        # Always show tolerance settings
-        for conf_key in [CONF_DRY_TOLERANCE, CONF_MOIST_TOLERANCE]:
-            # Default tolerances: 3% when not set in current_config
-            default_value = current_config.get(conf_key, 3)
-            schema_dict[vol.Optional(conf_key, default=default_value)] = (
-                selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        mode=selector.NumberSelectorMode.BOX,
-                        unit_of_measurement="%",
-                        min=1,
-                        max=20,
-                    )
-                )
-            )
-
+        # Use the unified schema with current config as defaults
         return flow_instance.async_show_form(
             step_id="humidity_options",
-            data_schema=vol.Schema(schema_dict),
+            data_schema=get_humidity_schema(defaults=current_config),
         )

--- a/custom_components/dual_smart_thermostat/schemas.py
+++ b/custom_components/dual_smart_thermostat/schemas.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_DRYER,
     CONF_FAN,
     CONF_FAN_AIR_OUTSIDE,
+    CONF_FAN_HOT_TOLERANCE,
     CONF_FAN_HOT_TOLERANCE_TOGGLE,
     CONF_FAN_MODE,
     CONF_FAN_ON_WITH_AC,
@@ -661,35 +662,85 @@ def get_openings_schema(selected_entities: list[str]):
     return vol.Schema(schema_dict)
 
 
-def get_fan_schema():
-    """Get fan configuration schema."""
+def get_fan_schema(defaults: dict[str, Any] | None = None):
+    """Get fan configuration schema.
+
+    Args:
+        defaults: Optional defaults dict to pre-populate selectors (used by options flow)
+
+    Returns:
+        Schema with fan configuration fields
+    """
+    defaults = defaults or {}
+
+    _LOGGER.debug(
+        "get_fan_schema called with defaults: fan=%s, fan_mode=%s, fan_on_with_ac=%s, fan_air_outside=%s",
+        defaults.get(CONF_FAN),
+        defaults.get(CONF_FAN_MODE),
+        defaults.get(CONF_FAN_ON_WITH_AC),
+        defaults.get(CONF_FAN_AIR_OUTSIDE),
+    )
+
     return vol.Schema(
         {
-            vol.Required(CONF_FAN): get_entity_selector(SWITCH_DOMAIN),
-            vol.Optional(CONF_FAN_ON_WITH_AC, default=True): get_boolean_selector(),
-            vol.Optional(CONF_FAN_AIR_OUTSIDE, default=False): get_boolean_selector(),
+            vol.Required(CONF_FAN, default=defaults.get(CONF_FAN)): get_entity_selector(
+                SWITCH_DOMAIN
+            ),
             vol.Optional(
-                CONF_FAN_HOT_TOLERANCE_TOGGLE, default=False
+                CONF_FAN_MODE, default=defaults.get(CONF_FAN_MODE, False)
             ): get_boolean_selector(),
+            vol.Optional(
+                CONF_FAN_ON_WITH_AC, default=defaults.get(CONF_FAN_ON_WITH_AC, True)
+            ): get_boolean_selector(),
+            vol.Optional(
+                CONF_FAN_AIR_OUTSIDE, default=defaults.get(CONF_FAN_AIR_OUTSIDE, False)
+            ): get_boolean_selector(),
+            vol.Optional(
+                CONF_FAN_HOT_TOLERANCE,
+                default=defaults.get(CONF_FAN_HOT_TOLERANCE, 0.5),
+            ): get_temperature_selector(min_value=0.0, max_value=10.0, step=0.1),
+            vol.Optional(
+                CONF_FAN_HOT_TOLERANCE_TOGGLE,
+                default=defaults.get(CONF_FAN_HOT_TOLERANCE_TOGGLE, vol.UNDEFINED),
+            ): get_entity_selector([INPUT_BOOLEAN_DOMAIN, BINARY_SENSOR_DOMAIN]),
         }
     )
 
 
-def get_humidity_schema():
-    """Get humidity configuration schema."""
+def get_humidity_schema(defaults: dict[str, Any] | None = None):
+    """Get humidity configuration schema.
+
+    Args:
+        defaults: Optional defaults dict to pre-populate selectors (used by options flow)
+
+    Returns:
+        Schema with humidity configuration fields
+    """
+    defaults = defaults or {}
+
     return vol.Schema(
         {
-            vol.Required(CONF_HUMIDITY_SENSOR): get_entity_selector(SENSOR_DOMAIN),
-            vol.Optional(CONF_DRYER): get_entity_selector(SWITCH_DOMAIN),
-            vol.Optional(CONF_TARGET_HUMIDITY, default=50): get_percentage_selector(),
-            vol.Optional(CONF_DRY_TOLERANCE, default=3): get_percentage_selector(
-                max_value=20
-            ),
-            vol.Optional(CONF_MOIST_TOLERANCE, default=3): get_percentage_selector(
-                max_value=20
-            ),
-            vol.Optional(CONF_MIN_HUMIDITY, default=30): get_percentage_selector(),
-            vol.Optional(CONF_MAX_HUMIDITY, default=99): get_percentage_selector(),
+            vol.Required(
+                CONF_HUMIDITY_SENSOR, default=defaults.get(CONF_HUMIDITY_SENSOR)
+            ): get_entity_selector(SENSOR_DOMAIN),
+            vol.Optional(
+                CONF_DRYER, default=defaults.get(CONF_DRYER)
+            ): get_entity_selector(SWITCH_DOMAIN),
+            vol.Optional(
+                CONF_TARGET_HUMIDITY, default=defaults.get(CONF_TARGET_HUMIDITY, 50)
+            ): get_percentage_selector(),
+            vol.Optional(
+                CONF_DRY_TOLERANCE, default=defaults.get(CONF_DRY_TOLERANCE, 3)
+            ): get_percentage_selector(max_value=20),
+            vol.Optional(
+                CONF_MOIST_TOLERANCE, default=defaults.get(CONF_MOIST_TOLERANCE, 3)
+            ): get_percentage_selector(max_value=20),
+            vol.Optional(
+                CONF_MIN_HUMIDITY, default=defaults.get(CONF_MIN_HUMIDITY, 30)
+            ): get_percentage_selector(),
+            vol.Optional(
+                CONF_MAX_HUMIDITY, default=defaults.get(CONF_MAX_HUMIDITY, 99)
+            ): get_percentage_selector(),
         }
     )
 

--- a/custom_components/dual_smart_thermostat/translations/en.json
+++ b/custom_components/dual_smart_thermostat/translations/en.json
@@ -339,17 +339,17 @@
                     "fan": "Fan switch",
                     "fan_mode": "Fan mode",
                     "fan_on_with_ac": "Fan with AC",
+                    "fan_air_outside": "Fan air outside",
                     "fan_hot_tolerance": "Fan hot tolerance",
-                    "fan_hot_tolerance_toggle": "Fan tolerance toggle",
-                    "fan_air_outside": "Fan air outside"
+                    "fan_hot_tolerance_toggle": "Fan tolerance toggle"
                 },
                 "data_description": {
                     "fan": "Entity ID for fan switch. Used to control air circulation and improve temperature distribution throughout the space.",
                     "fan_mode": "Enable fan as a separate HVAC mode. When enabled, FAN mode becomes available in addition to heat, cool, and auto modes, allowing fan-only operation.",
                     "fan_on_with_ac": "Automatically turn on fan when cooling (AC) is active. Improves cooling efficiency and air circulation during cooling cycles.",
-                    "fan_hot_tolerance": "Temperature difference above target that triggers fan activation. For example, with target 25°C and tolerance 1°C, fan activates when temperature reaches 26°C.",
-                    "fan_hot_tolerance_toggle": "Entity ID for input boolean that can toggle fan hot tolerance on/off. Allows dynamic control of when fan should activate based on temperature.",
-                    "fan_air_outside": "Enable outside air circulation when outside temperature is more favorable than inside temperature. Requires outside temperature sensor to be configured for intelligent outside air usage."
+                    "fan_air_outside": "Enable outside air circulation when outside temperature is more favorable than inside temperature. Requires outside temperature sensor to be configured for intelligent outside air usage.",
+                    "fan_hot_tolerance": "Temperature range above target where fan is used instead of AC. For example, with target 25°C, hot_tolerance 1°C, and fan_hot_tolerance 0.5°C: fan activates at 26°C (target + hot_tolerance), AC activates at 26.5°C (target + hot_tolerance + fan_hot_tolerance). Default: 0.5°C.",
+                    "fan_hot_tolerance_toggle": "Optional entity ID for input_boolean to dynamically enable/disable the fan_hot_tolerance feature. When off, AC is used immediately instead of trying fan first. When not configured, the fan_hot_tolerance feature is always enabled."
                 }
             },
             "humidity": {
@@ -682,17 +682,17 @@
                     "fan": "Fan switch",
                     "fan_mode": "Fan mode",
                     "fan_on_with_ac": "Fan with AC",
+                    "fan_air_outside": "Fan air outside",
                     "fan_hot_tolerance": "Fan hot tolerance",
-                    "fan_hot_tolerance_toggle": "Fan tolerance toggle",
-                    "fan_air_outside": "Fan air outside"
+                    "fan_hot_tolerance_toggle": "Fan tolerance toggle"
                 },
                 "data_description": {
                     "fan": "Entity ID for fan switch. Used to control air circulation and improve temperature distribution.",
                     "fan_mode": "Enable fan as a separate HVAC mode. Allows fan-only operation.",
                     "fan_on_with_ac": "Automatically turn on fan when cooling (AC) is active. Improves cooling efficiency.",
-                    "fan_hot_tolerance": "Temperature difference above target that triggers fan activation.",
-                    "fan_hot_tolerance_toggle": "Entity ID for input boolean that can toggle fan hot tolerance on/off.",
-                    "fan_air_outside": "Enable outside air circulation when outside temperature is more favorable than inside temperature."
+                    "fan_air_outside": "Enable outside air circulation when outside temperature is more favorable than inside temperature.",
+                    "fan_hot_tolerance": "Temperature range above target where fan is used instead of AC. Default: 0.5°C.",
+                    "fan_hot_tolerance_toggle": "Optional entity ID for input_boolean to toggle the fan_hot_tolerance feature on/off."
                 }
             },
             "humidity_options": {

--- a/specs/001-develop-config-and/HOUSEKEEPING.md
+++ b/specs/001-develop-config-and/HOUSEKEEPING.md
@@ -1,0 +1,115 @@
+# Housekeeping Instructions for All Tasks
+
+This document explains how to mark tasks as complete in the specification files.
+
+## Quick Reference
+
+All GitHub issues (#415, #416, #418-422, #436) now include housekeeping instructions in their description.
+
+## Standard Housekeeping Workflow
+
+When you complete a task, follow these steps:
+
+### 1. Mark task as complete in tasks.md
+
+Edit `specs/001-develop-config-and/tasks.md` and update the task header:
+
+**Example:**
+```diff
+- T005 — Complete `heater_cooler` implementation (Phase 1C) 🔥 [TDD APPROACH] — [GitHub Issue #415]
++ T005 — Complete `heater_cooler` implementation ✅ [COMPLETED] — [GitHub Issue #415]
+```
+
+### 2. Update task ordering section
+
+In the "Task Ordering and dependency notes" section:
+- Move the completed task to the ✅ completed list
+- Update the "Recommended Sequential Path" diagram if needed
+
+### 3. Commit changes
+
+```bash
+git add specs/001-develop-config-and/tasks.md
+git commit -m "docs: Mark T{XXX} ({task_name}) as complete in tasks.md"
+```
+
+### 4. Close the GitHub issue
+
+```bash
+gh issue close {ISSUE_NUMBER} --comment "Task completed. tasks.md updated to reflect completion."
+```
+
+Or close via GitHub web UI with a completion comment.
+
+## Tasks with Housekeeping Instructions
+
+All open issues now have housekeeping sections:
+
+| Task | Issue | Priority | Lines in tasks.md |
+|------|-------|----------|-------------------|
+| T005 - heater_cooler | [#415](https://github.com/swingerman/ha-dual-smart-thermostat/issues/415) | 🔥 High | 196-336 |
+| T006 - heat_pump | [#416](https://github.com/swingerman/ha-dual-smart-thermostat/issues/416) | 🔥 High | 338-410 |
+| T007A - Feature interactions | [#436](https://github.com/swingerman/ha-dual-smart-thermostat/issues/436) | 🔥 Critical | 422-539 |
+| T008 - Normalize keys | [#418](https://github.com/swingerman/ha-dual-smart-thermostat/issues/418) | ✅ Medium | 541-550 |
+| T009 - models.py | [#419](https://github.com/swingerman/ha-dual-smart-thermostat/issues/419) | ✅ Medium | 552-563 |
+| T010 - Test reorg | [#420](https://github.com/swingerman/ha-dual-smart-thermostat/issues/420) | ⚪ Optional | 565-579 |
+| T011 - Schema consolidation | [#421](https://github.com/swingerman/ha-dual-smart-thermostat/issues/421) | ⚪ Optional | 581-596 |
+| T012 - Documentation | [#422](https://github.com/swingerman/ha-dual-smart-thermostat/issues/422) | ✅ Medium | 598-611 |
+
+## Current Release Path
+
+```
+T004 → {T005, T006} → T007A → T008 → {T009, T012} → RELEASE
+✅      (parallel)      ↑               (parallel)
+                    [Critical
+                     for features]
+```
+
+**Legend:**
+- ✅ Completed
+- 🔥 High Priority / Critical
+- ✅ Medium Priority
+- ⚪ Optional
+
+## Already Completed Tasks
+
+These tasks are already marked as complete:
+
+| Task | Issue | Status |
+|------|-------|--------|
+| T001 - E2E Playwright scaffold | [#411](https://github.com/swingerman/ha-dual-smart-thermostat/issues/411) | ✅ Closed |
+| T002 - Playwright tests | [#412](https://github.com/swingerman/ha-dual-smart-thermostat/issues/412) | ✅ Closed |
+| T003 - Complete E2E implementation | [#413](https://github.com/swingerman/ha-dual-smart-thermostat/issues/413) | ✅ Closed |
+| T004 - Remove Advanced option | [#414](https://github.com/swingerman/ha-dual-smart-thermostat/issues/414) | ✅ Closed |
+| T007 - Python unit tests | [#417](https://github.com/swingerman/ha-dual-smart-thermostat/issues/417) | ❌ Removed (duplicate) |
+
+## Verification
+
+After marking a task complete, verify:
+
+1. ✅ Task header updated in tasks.md with ✅ [COMPLETED] marker
+2. ✅ Task moved to completed list in "Task Ordering" section
+3. ✅ Changes committed to git
+4. ✅ GitHub issue closed with comment
+5. ✅ No references to the task remain in "CURRENT PRIORITIES" section
+
+## Tips
+
+- **Use grep to find task references:**
+  ```bash
+  grep -n "T005" specs/001-develop-config-and/tasks.md
+  ```
+
+- **Check issue status:**
+  ```bash
+  gh issue list --state all | grep "T005"
+  ```
+
+- **View task in context:**
+  ```bash
+  sed -n '196,336p' specs/001-develop-config-and/tasks.md
+  ```
+
+## Questions?
+
+If you're unsure about any step, check the housekeeping instructions in the GitHub issue itself - each issue has specific line numbers and commands tailored to that task.

--- a/specs/001-develop-config-and/OPTIONS_FLOW_BUG_FIX.md
+++ b/specs/001-develop-config-and/OPTIONS_FLOW_BUG_FIX.md
@@ -1,0 +1,166 @@
+# Options Flow Bug Fix: Feature Settings Not Persisting
+
+## UPDATE: Second Bug Found and Fixed
+
+After the initial fix, manual testing revealed a second bug where the options flow would show the wrong system type fields. This was caused by improperly merging transient flow state flags into the collected_config, which confused the flow navigation logic.
+
+### The Second Bug
+When opening options flow for a heater_cooler system, it would show AC-only fields instead. This happened because transient flags like "fan_options_shown" were being copied from the saved config into collected_config, which broke the flow navigation.
+
+### The Second Fix
+Modified `async_step_basic` to exclude transient flow state flags when merging current_config into collected_config. These flags control flow navigation and should never be persisted or copied between flow sessions.
+
+---
+
+## The Problem (Original)
+
+When users configured features like Fan or Humidity in the options flow and saved their changes, those settings would not persist. When they reopened the options flow, the settings would revert to defaults or show incorrect values.
+
+### Root Cause
+
+Home Assistant's `OptionsFlow` saves changes to `config_entry.options`, NOT to `config_entry.data`. However, the options flow code was only reading from `config_entry.data`, which contains the original configuration from the initial setup (ConfigFlow).
+
+This created a mismatch:
+- **Saved location**: `config_entry.options` (where HA stores option changes)
+- **Read location**: `config_entry.data` (original config, never updated)
+
+### Example Scenario
+
+1. User creates a Heater/Cooler system with a fan during initial setup
+   - Sets `fan_mode=False` and `fan_on_with_ac=True`
+   - Saved to `config_entry.data`
+
+2. User opens options flow and changes `fan_mode=True`
+   - Changes saved to `config_entry.options`
+   - `config_entry.data` remains unchanged
+
+3. User reopens options flow
+   - Code reads from `config_entry.data` (old values)
+   - Shows `fan_mode=False` instead of `True`
+   - User's changes appear to be lost!
+
+## The Fix
+
+Created a new helper method `_get_current_config()` that properly merges both sources:
+
+```python
+def _get_current_config(self) -> dict[str, Any]:
+    """Get current configuration merging data and options.
+
+    Home Assistant OptionsFlow saves to entry.options, not entry.data.
+    This method merges both, with options taking precedence.
+    """
+    entry = self._get_entry()
+    options = getattr(entry, "options", {}) or {}
+    # Handle both real ConfigEntry objects and test Mocks
+    data = entry.data if isinstance(entry.data, dict) else {}
+    options = options if isinstance(options, dict) else {}
+    return {**data, **options}
+```
+
+This method:
+1. Gets the original config from `entry.data`
+2. Gets any saved changes from `entry.options`
+3. Merges them with options taking precedence
+4. Handles test Mocks gracefully
+
+### Changed Locations
+
+Replaced all 10 occurrences of `self._get_entry().data` with `self._get_current_config()` in:
+
+- `async_step_init()` - Initial options flow step
+- `async_step_basic()` - Basic settings step
+- `_determine_options_next_step()` - Flow navigation logic
+- `async_step_dual_stage_options()` - Dual stage system options
+- `async_step_features()` - Feature selection
+- `async_step_fan_options()` - Fan configuration
+- `async_step_floor_options()` - Floor sensor options
+
+## Testing
+
+### Unit Tests (All Pass ✅)
+
+1. **test_fan_boolean_false_persistence.py** - 5 tests
+   - Verifies boolean False values persist correctly
+   - Tests that `fan_on_with_ac=False` shows in options flow
+   - Tests that `fan_mode=True` persists and displays
+
+2. **test_options_flow_feature_persistence.py** - 6 tests
+   - Fan settings prefilled correctly for all system types
+   - Humidity settings prefilled correctly
+   - Default values when features not configured
+
+3. **All config_flow tests** - 72 tests total
+   - No regressions in existing functionality
+
+### Manual Testing Steps
+
+To verify the fix works in Home Assistant:
+
+1. **Initial Setup**:
+   ```
+   - Create a new Heater/Cooler system
+   - Add a fan with specific settings:
+     * fan_mode: Enable (checkbox checked)
+     * fan_on_with_ac: Enable (checkbox checked)
+   - Complete the setup
+   ```
+
+2. **Modify via Options**:
+   ```
+   - Open Integration → Configure (options flow)
+   - Navigate to Fan Options
+   - Change fan_mode to Disabled (uncheck)
+   - Save changes
+   ```
+
+3. **Verify Persistence**:
+   ```
+   - Reopen Integration → Configure
+   - Navigate to Fan Options
+   - ✅ Expected: fan_mode checkbox is UNCHECKED
+   - ❌ Bug (before fix): fan_mode checkbox was CHECKED (reverted to default)
+   ```
+
+4. **Check Storage File** (optional):
+   ```bash
+   # Check what's actually saved
+   cat config/.storage/core.config_entries | python3 -m json.tool | grep -A 30 "dual_smart_thermostat"
+   ```
+
+   Should see:
+   ```json
+   {
+     "data": {
+       "fan_mode": true,  // Original config
+       ...
+     },
+     "options": {
+       "fan_mode": false,  // Updated via options flow
+       ...
+     }
+   }
+   ```
+
+## Files Changed
+
+- `custom_components/dual_smart_thermostat/options_flow.py`
+  - Added `_get_current_config()` helper method that merges entry.data and entry.options
+  - Replaced 10 occurrences of `self._get_entry().data` with `self._get_current_config()`
+  - Modified `async_step_basic()` to preserve unmodified fields while excluding transient flags
+  - Added debug logging for troubleshooting
+
+- `tests/config_flow/test_heater_cooler_flow.py`
+  - Fixed test to check behavior (form fields) instead of implementation details (collected_config)
+
+## Impact
+
+- ✅ Feature settings now persist correctly across options flow sessions
+- ✅ Users can modify fan, humidity, and other feature settings reliably
+- ✅ No breaking changes - fully backward compatible
+- ✅ All 72 existing tests pass
+- ✅ 11 new tests specifically for persistence scenarios
+
+## Related Issues
+
+This fix addresses the core persistence problem discovered during T005 (heater_cooler implementation) testing. This is a critical bug that affects ALL feature configuration in the options flow, not just fan settings.

--- a/specs/001-develop-config-and/github-issues-update.md
+++ b/specs/001-develop-config-and/github-issues-update.md
@@ -1,0 +1,195 @@
+# GitHub Issues Update - Acceptance Criteria (2025-01-06)
+
+This document contains the updated acceptance criteria for GitHub issues #415 and #416.
+
+---
+
+## Issue #415: Complete `heater_cooler` implementation
+
+**URL**: https://github.com/swingerman/ha-dual-smart-thermostat/issues/415
+
+### Proposed Update
+
+Add the following section after "## Special Notes" (or replace existing "## Acceptance Criteria"):
+
+```markdown
+## Acceptance Criteria (UPDATED 2025-01-06 - TDD + DATA VALIDATION)
+
+### Test-Driven Development (TDD)
+- ✅ All tests written BEFORE implementation (RED phase)
+- ✅ Tests fail initially with clear error messages
+- ✅ Implementation makes tests pass (GREEN phase)
+- ✅ No regressions in existing simple_heater/ac_only tests
+
+### Config Flow - Core Requirements
+1. ✅ **Flow completes without error** - All steps navigate successfully to completion
+2. ✅ **Valid configuration is created** - Config entry data matches `data-model.md` structure
+3. ✅ **Climate entity is created** - Verify entity appears in HA with correct entity_id
+
+### Config Flow - Data Structure Validation
+- ✅ All required fields from schema are present in saved config
+- ✅ Field types match expected types (entity_id strings, numeric values, booleans)
+- ✅ System-specific fields: `heater`, `cooler`, `target_sensor` are entity_ids
+- ✅ `heat_cool_mode` field exists with correct boolean default
+- ✅ Advanced settings are flattened to top level (tolerances, min_cycle_duration)
+- ✅ `name` field is collected (bug fix 2025-01-06 verified)
+
+### Options Flow - Core Requirements
+1. ✅ **Flow completes without error** - All steps navigate successfully
+2. ✅ **Configuration is updated correctly** - Modified fields are persisted
+3. ✅ **Unmodified fields are preserved** - Fields not changed remain intact
+
+### Options Flow - Data Structure Validation
+- ✅ `name` field is omitted in options flow
+- ✅ Options flow pre-fills all heater_cooler fields from existing config
+- ✅ System type is displayed but non-editable
+- ✅ Updated config matches `data-model.md` structure after changes
+
+### Field-Specific Validation (Unit Tests)
+- ✅ Optional entity fields accept empty values (vol.UNDEFINED pattern)
+- ✅ Numeric fields have correct defaults when not provided
+- ✅ Required fields (heater, cooler, sensor) raise validation errors when missing
+- ✅ Validation: same heater/cooler entity produces error
+- ✅ Validation: same heater/sensor entity produces error
+
+### Feature Integration
+- ✅ Features step allows toggling features on/off
+- ✅ Enabled features show their configuration steps
+- ✅ Feature settings are saved under correct keys
+- ✅ Feature settings match schema definitions
+
+### Business Logic Validation
+- ✅ HeaterCoolerDevice class works correctly with schema
+- ✅ Config flow creates working climate entity
+- ✅ Climate entity has correct HVAC modes for heater_cooler system
+
+### Quality Gates
+- ✅ All code must pass linting checks
+- ✅ All unit tests must pass
+- ✅ Pull requests must target branch `copilot/fix-157`
+
+### Scope Notes
+- ❌ **REMOVED**: E2E test coverage (covered by simple_heater/ac_only E2E tests)
+- ✅ **FOCUS**: Python unit/integration tests for data validation and business logic
+
+### Bug Fixes Applied (2025-01-06)
+- ✅ Missing name field in get_heater_cooler_schema() - config_flow.py:248
+- ✅ Missing fan_hot_tolerance numeric field - schemas.py:690
+- ✅ fan_hot_tolerance_toggle validation error (vol.UNDEFINED) - schemas.py:695
+- ✅ Unified fan/humidity schemas to remove duplication
+- ✅ Added translations for fan_hot_tolerance fields
+- ✅ Updated README.md documentation
+```
+
+---
+
+## Issue #416: Complete `heat_pump` implementation
+
+**URL**: https://github.com/swingerman/ha-dual-smart-thermostat/issues/416
+
+### Proposed Update
+
+Add the following section after "## Special Notes" (or replace existing "## Acceptance Criteria"):
+
+```markdown
+## Acceptance Criteria (UPDATED 2025-01-06 - TDD + DATA VALIDATION)
+
+### Test-Driven Development (TDD)
+- ✅ All tests written BEFORE implementation (RED phase)
+- ✅ Tests fail initially with clear error messages
+- ✅ Implementation makes tests pass (GREEN phase)
+- ✅ No regressions in existing system type tests
+
+### Config Flow - Core Requirements
+1. ✅ **Flow completes without error** - All steps navigate successfully to completion
+2. ✅ **Valid configuration is created** - Config entry data matches `data-model.md` structure
+3. ✅ **Climate entity is created** - Verify entity appears in HA with correct entity_id
+
+### Config Flow - Data Structure Validation
+- ✅ All required fields from schema are present in saved config
+- ✅ Field types match expected types (entity_id strings, numeric values, booleans)
+- ✅ System-specific fields: `heater` (entity_id), `heat_pump_cooling` (entity_id or boolean)
+- ✅ `target_sensor` is entity_id
+- ✅ Advanced settings are flattened to top level (tolerances, min_cycle_duration)
+- ✅ `name` field is collected in config flow
+
+### Options Flow - Core Requirements
+1. ✅ **Flow completes without error** - All steps navigate successfully
+2. ✅ **Configuration is updated correctly** - Modified fields are persisted
+3. ✅ **Unmodified fields are preserved** - Fields not changed remain intact
+
+### Options Flow - Data Structure Validation
+- ✅ `name` field is omitted in options flow
+- ✅ Options flow pre-fills all heat_pump fields from existing config
+- ✅ System type is displayed but non-editable
+- ✅ Updated config matches `data-model.md` structure after changes
+
+### Field-Specific Validation (Unit Tests)
+- ✅ `heat_pump_cooling` accepts entity_id (preferred) or boolean
+- ✅ `heat_pump_cooling` entity selector functionality works correctly
+- ✅ Optional entity fields accept empty values (vol.UNDEFINED pattern)
+- ✅ Numeric fields have correct defaults when not provided
+- ✅ Required fields (heater, sensor) raise validation errors when missing
+
+### Feature Integration
+- ✅ Features step allows toggling features on/off
+- ✅ Enabled features show their configuration steps
+- ✅ Feature settings are saved under correct keys
+- ✅ Feature settings match schema definitions
+
+### Business Logic Validation
+- ✅ HeatPumpDevice class works correctly with schema
+- ✅ Config flow creates working climate entity
+- ✅ Climate entity has correct HVAC modes based on heat_pump_cooling state
+- ✅ Dynamic heat_pump_cooling entity state changes update available HVAC modes
+
+### Quality Gates
+- ✅ All code must pass linting checks
+- ✅ All unit tests must pass
+- ✅ Pull requests must target branch `copilot/fix-157`
+
+### Scope Notes
+- ❌ **REMOVED**: E2E test coverage (covered by simple_heater/ac_only E2E tests)
+- ✅ **FOCUS**: Python unit/integration tests for data validation and business logic
+```
+
+---
+
+## How to Apply These Updates
+
+### Option 1: Via GitHub Web UI
+1. Navigate to each issue URL
+2. Click "Edit" on the issue description
+3. Replace the "## Acceptance Criteria" section with the new content above
+4. Save changes
+
+### Option 2: Via GitHub CLI (when available)
+```bash
+# Install GitHub CLI if needed
+# Then update issues programmatically
+
+# Issue #415
+gh issue edit 415 --body-file /path/to/new-body.md
+
+# Issue #416
+gh issue edit 416 --body-file /path/to/new-body.md
+```
+
+### Option 3: Bulk Update Script
+Create individual body files and use the script in this directory if GitHub CLI becomes available.
+
+---
+
+## Summary of Changes
+
+Both issues now have:
+- ✅ Comprehensive acceptance criteria matching tasks.md
+- ✅ TDD approach clearly documented
+- ✅ Core requirements (flow works + valid config)
+- ✅ Data structure validation requirements
+- ✅ Business logic validation requirements
+- ✅ Clear scope notes (Python tests, not E2E)
+- ✅ Quality gates unchanged
+- ✅ Issue #415 includes bug fixes from 2025-01-06
+
+These updates align GitHub issues with the refined strategy documented in `tasks.md`.

--- a/specs/001-develop-config-and/github-sync-status.md
+++ b/specs/001-develop-config-and/github-sync-status.md
@@ -1,0 +1,110 @@
+# GitHub Issues Sync Status (2025-01-06)
+
+## Summary
+✅ All GitHub issues are now synced with tasks.md
+
+## Issues Status
+
+### ✅ Completed/Closed Tasks
+- **T001** (#411) - E2E Playwright scaffold - ✅ CLOSED (completed)
+- **T002** (#412) - Playwright tests for config & options flows - ✅ CLOSED (completed)
+- **T003** (#413) - Complete E2E implementation - ✅ CLOSED (completed beyond scope)
+- **T004** (#414) - Remove Advanced Custom Setup option - ✅ CLOSED (completed)
+- **T007** (#417) - Python Unit Tests - ✅ CLOSED (removed as duplicate of T005/T006)
+
+### 🔥 High Priority - Active Development
+- **T005** (#415) - Complete heater_cooler implementation
+  - Status: ✅ SYNCED with acceptance criteria (updated 2025-01-06)
+  - Includes: TDD approach, comprehensive acceptance criteria, bug fixes documented
+
+- **T006** (#416) - Complete heat_pump implementation
+  - Status: ✅ SYNCED with acceptance criteria (updated 2025-01-06)
+  - Includes: TDD approach, comprehensive acceptance criteria, heat_pump_cooling specifics
+
+### ✅ Medium Priority - Post Implementation
+- **T008** (#418) - Normalize collected_config keys and constants
+  - Status: ✅ OPEN (no updates needed - original content still valid)
+
+- **T009** (#419) - Add models.py dataclasses
+  - Status: ✅ OPEN (no updates needed - original content still valid)
+
+### ⚪ Optional - Not Blocking Release
+- **T010** (#420) - Perform test reorganization
+  - Status: ✅ SYNCED with OPTIONAL priority (updated 2025-01-06)
+  - Added: "PRIORITY: ⚪ OPTIONAL - Nice-to-have, not blocking release"
+  - Added: "Release Impact: None - Can be done post-release"
+
+- **T011** (#421) - Investigate schema duplication
+  - Status: ✅ SYNCED with OPTIONAL priority (updated 2025-01-06)
+  - Added: "PRIORITY: ⚪ OPTIONAL - Nice-to-have, not blocking release"
+  - Added: "Release Impact: None - Only do if duplication becomes painful"
+
+### ✅ Essential - Release Preparation
+- **T012** (#422) - Polish documentation & release prep
+  - Status: ✅ OPEN (no updates needed - original content still valid)
+
+## Critical Path to Release (Updated)
+
+```
+T004 → {T005, T006} → T008 → {T009, T012} → RELEASE
+✅      (parallel)      📋      (parallel)
+```
+
+**Legend:**
+- ✅ Completed
+- 🔥 High Priority (T005, T006)
+- ✅ Medium Priority (T008, T009, T012)
+- ⚪ Optional (T010, T011)
+
+## Key Changes Made (2025-01-06)
+
+1. **T007 Removed**: Duplicate of T005/T006 acceptance criteria
+   - All required tests moved into T005/T006
+   - GitHub issue #417 closed with explanation
+
+2. **T005/T006 Enhanced**: Added comprehensive acceptance criteria
+   - TDD approach documented
+   - Config/options flow core requirements
+   - Data structure validation
+   - Field-specific validation
+   - Business logic validation
+   - Bug fixes documented (T005)
+
+3. **T010/T011 Marked Optional**: Not blocking release
+   - Clear "OPTIONAL" priority added
+   - "Release Impact: None" documented
+   - Can be done post-release
+
+4. **Task Ordering Revised**: Clear critical path defined
+   - T004 first (cleanup)
+   - T005/T006 parallel (core implementation with tests)
+   - T008 cleanup (normalize keys)
+   - T009/T012 parallel (models + docs)
+   - T010/T011 optional post-release
+
+## Verification Commands
+
+Check all issues are synced:
+```bash
+# List open tasks
+gh issue list | grep -E "T00[5-9]|T01[0-2]"
+
+# Check T005/T006 have acceptance criteria
+gh issue view 415 | grep -i "acceptance criteria"
+gh issue view 416 | grep -i "acceptance criteria"
+
+# Check T010/T011 marked optional
+gh issue view 420 | grep -i "optional"
+gh issue view 421 | grep -i "optional"
+
+# Verify T007 is closed
+gh issue view 417 --json state --jq '.state'
+```
+
+## Next Steps
+
+1. ✅ Start T004 (Remove Advanced option) - if not already complete
+2. 🔥 Implement T005/T006 in parallel with TDD approach
+3. ✅ T008 normalization after learning from T005/T006
+4. ✅ T009/T012 in parallel for release prep
+5. ⚪ T010/T011 optional post-release improvements

--- a/specs/001-develop-config-and/tasks.md
+++ b/specs/001-develop-config-and/tasks.md
@@ -7,7 +7,88 @@ Guidance for reviewers:
 - All code tasks follow TDD: create failing tests first, implement changes, then make tests pass.
 - Keep PRs small and focused; prefer single responsibility per PR.
 
-Summary: ✅ E2E scaffold (T001), config flow tests (T002), and complete E2E implementation (T003) COMPLETED with comprehensive implementation insights documented. **T003 ACHIEVED BEYOND ORIGINAL SCOPE**: Full E2E coverage for both system types (config + options flows) with CI integration. Current priority: Remove Advanced option (T004), expand Python unit tests for climate entity validation (T007 - ELEVATED PRIORITY), complete heater_cooler/heat_pump with Python-first approach (T005-T006), then polish & release (T012).
+Summary: ✅ E2E scaffold (T001), config flow tests (T002), and complete E2E implementation (T003) COMPLETED with comprehensive implementation insights documented. **T003 ACHIEVED BEYOND ORIGINAL SCOPE**: Full E2E coverage for both system types (config + options flows) with CI integration. ❌ T007 REMOVED (duplicate of T005/T006). 🆕 **T007A ADDED** (feature interaction testing - CRITICAL). **Current priority**: Remove Advanced option (T004), complete heater_cooler/heat_pump with TDD approach (T005-T006), test feature interactions & HVAC modes (T007A - NEW CRITICAL TASK), normalize keys (T008), then polish & release (T009, T012).
+
+---
+
+## Universal Acceptance Criteria Template (All System Types)
+
+This template applies to **all system type implementations** (simple_heater, ac_only, heater_cooler, heat_pump).
+
+### Test-Driven Development (TDD)
+- ✅ All tests written BEFORE implementation (RED phase)
+- ✅ Tests fail initially with clear error messages
+- ✅ Implementation makes tests pass (GREEN phase)
+- ✅ No regressions in existing system type tests
+
+### Config Flow - Core Requirements
+1. ✅ **Flow completes without error** - All steps navigate successfully to completion
+2. ✅ **Valid configuration is created** - Config entry data matches `data-model.md` structure
+3. ✅ **Climate entity is created** - Verify entity appears in HA with correct entity_id
+
+### Config Flow - Data Structure Validation
+- ✅ All required fields from schema are present in saved config
+- ✅ Field types match expected types (entity_id strings, numeric values, booleans)
+- ✅ System-specific fields are correctly configured (varies by system type)
+- ✅ Advanced settings are flattened to top level (tolerances, min_cycle_duration)
+- ✅ `name` field is collected
+
+### Options Flow - Core Requirements
+1. ✅ **Flow completes without error** - All steps navigate successfully
+2. ✅ **Configuration is updated correctly** - Modified fields are persisted
+3. ✅ **Unmodified fields are preserved** - Fields not changed remain intact
+
+### Options Flow - Data Structure Validation
+- ✅ `name` field is omitted in options flow
+- ✅ Options flow pre-fills all fields from existing config
+- ✅ System type is displayed but non-editable
+- ✅ Updated config matches `data-model.md` structure after changes
+
+### E2E Persistence Tests (CRITICAL)
+**Each system type MUST have an E2E test** that validates the complete lifecycle:
+- ✅ **test_e2e_simple_heater_persistence.py** - Simple heater config → options → persistence
+- ✅ **test_e2e_ac_only_persistence.py** - AC only config → options → persistence
+- ✅ **test_e2e_heater_cooler_persistence.py** - Heater/cooler config → options → persistence
+- ⏳ **test_e2e_heat_pump_persistence.py** - TODO: Add when heat_pump is implemented (T006)
+- ⏳ **test_e2e_dual_stage_persistence.py** - TODO: Add if dual_stage needs testing
+- ⏳ **test_e2e_floor_heating_persistence.py** - TODO: Add if floor_heating needs testing
+
+**What E2E tests validate:**
+1. Complete config flow creates correct entry (no transient flags saved)
+2. Options flow shows pre-filled values from config entry
+3. Feature toggles show checked state when features are configured
+4. Changes made in options flow persist correctly (to entry.options)
+5. Original values preserved (in entry.data)
+6. Reopening options flow shows updated values (merged data + options)
+7. Unmodified fields are preserved during partial updates
+
+**Why these tests are critical:**
+- Would have caught the options flow persistence bug (mappingproxy handling)
+- Validate real Home Assistant behavior, not just Mocks
+- Test actual storage flow (data vs options)
+- Prevent regressions in persistence logic
+
+### Field-Specific Validation (Unit Tests)
+- ✅ Optional entity fields accept empty values (vol.UNDEFINED pattern)
+- ✅ Numeric fields have correct defaults when not provided
+- ✅ Required fields raise validation errors when missing
+- ✅ Entity field validation prevents duplicate entities where applicable
+
+### Feature Integration
+- ✅ Features step allows toggling features on/off
+- ✅ Enabled features show their configuration steps
+- ✅ Feature settings are saved under correct keys
+- ✅ Feature settings match schema definitions
+
+### Business Logic Validation
+- ✅ Device class works correctly with schema (HeaterDevice, CoolerDevice, etc.)
+- ✅ Config flow creates working climate entity
+- ✅ Climate entity has correct HVAC modes for system type
+- ✅ System-specific behavior works as expected
+
+### Scope Notes
+- ❌ **E2E tests**: Not required for new system types (covered by simple_heater/ac_only)
+- ✅ **Python tests**: Focus on unit/integration tests for data validation and business logic
 
 ---
 
@@ -143,76 +224,343 @@ T004 — Remove Advanced (Custom Setup) option (Phase 1B) — [GitHub Issue #414
   - `pytest -q` passes locally; schema shows only four types.
 - Parallelization: Not parallel; recommend doing after T001 and before T005/T006.
 
-T005 — Complete `heater_cooler` implementation (Phase 1C) 📉 [REDUCED SCOPE] — [GitHub Issue #415](https://github.com/swingerman/ha-dual-smart-thermostat/issues/415)
-- **SCOPE REDUCTION**: Focus on Python implementation and unit tests only; E2E tests removed from scope
-- Files to edit/create:
-  - `custom_components/dual_smart_thermostat/schemas.py` (add/complete `get_heater_cooler_schema`)
-  - `custom_components/dual_smart_thermostat/feature_steps/` (ensure all per-feature steps handle `heater_cooler` cases)
-  - Tests: `tests/features/heater_cooler/test_config_flow.py`, `tests/features/heater_cooler/test_options_flow.py`
-  - **NEW**: `tests/unit/test_heater_cooler_climate_entity.py` — Test climate entity generation for heater_cooler
-- **REMOVED FROM SCOPE**: E2E Playwright tests (too expensive to maintain)
-- TDD guidance:
-  1. Add contract tests under T007 to define expected keys for `heater_cooler`.
-  2. Implement schema and per-feature logic to satisfy tests.
-  3. Focus on Python unit tests for business logic validation.
-- Updated Acceptance criteria:
-  - ✅ Unit and contract tests for `heater_cooler` pass.
-  - ✅ Python tests validate climate entity structure and behavior.
-  - ✅ E2E tests for `simple_heater`/`ac_only` remain green.
-  - ❌ **REMOVED**: E2E test coverage requirement for `heater_cooler`.
-- Parallelization: Can be run in parallel with T006 and T007 if no shared files are edited simultaneously.
+T005 — Complete `heater_cooler` implementation (Phase 1C) 🔥 [TDD APPROACH] — [GitHub Issue #415](https://github.com/swingerman/ha-dual-smart-thermostat/issues/415)
+- **UPDATED APPROACH** (2025-01-06): Test-first implementation using bugs discovered today as foundation
+- **Strategy**: Write failing tests FIRST (RED), implement code (GREEN), validate no regressions (REFACTOR)
+
+**Phase 1: Write Failing Tests FIRST (RED)**
+- Files to create:
+  - `tests/config_flow/test_heater_cooler_config_flow.py`:
+    - ✅ Test name field is required and collected (bug fix 2025-01-06)
+    - ✅ Test fan_hot_tolerance field exists with default 0.5 (bug fix 2025-01-06)
+    - ✅ Test fan_hot_tolerance_toggle is optional (vol.UNDEFINED when empty) (bug fix 2025-01-06)
+    - ❌ Test heater field is required
+    - ❌ Test cooler field is required
+    - ❌ Test heat_cool_mode toggle exists and defaults correctly
+    - ❌ Test advanced_settings section extracts and flattens correctly
+    - ❌ Test validation: same heater/cooler entity error
+    - ❌ Test validation: same heater/sensor entity error
+    - ❌ Test successful submission proceeds to features step
+
+  - `tests/config_flow/test_heater_cooler_options_flow.py`:
+    - ❌ Test options flow omits name field
+    - ❌ Test options flow pre-fills all heater_cooler fields from existing config
+    - ❌ Test options flow preserves unmodified fields
+    - ❌ Test system type display (non-editable in options)
+
+  - `tests/unit/test_heater_cooler_schema.py`:
+    - ❌ Test get_heater_cooler_schema(defaults=None, include_name=True) includes all required fields
+    - ❌ Test get_heater_cooler_schema(defaults=None, include_name=False) omits name field
+    - ❌ Test get_heater_cooler_schema(defaults={...}) pre-fills values correctly
+    - ❌ Test all fields use correct selectors (entity, number, boolean)
+    - ❌ Test optional entity fields use vol.UNDEFINED when no default provided
+    - ❌ Test advanced_settings section structure
+
+**Phase 2: Implement Code to Pass Tests (GREEN)**
+- Files to edit:
+  - `custom_components/dual_smart_thermostat/schemas.py`:
+    - ✅ COMPLETED: get_heater_cooler_schema(defaults, include_name) with name field
+    - ✅ COMPLETED: fan_hot_tolerance numeric field with default 0.5
+    - ✅ COMPLETED: fan_hot_tolerance_toggle using vol.UNDEFINED
+    - ❌ TODO: Verify all other fields (heater, cooler, heat_cool_mode, tolerances)
+
+  - `custom_components/dual_smart_thermostat/config_flow.py`:
+    - ✅ COMPLETED: async_step_heater_cooler calls schema with defaults=None, include_name=True
+    - ❌ TODO: Verify validation logic for heater/cooler/sensor
+
+  - `custom_components/dual_smart_thermostat/options_flow.py`:
+    - ❌ TODO: Verify async_step_basic uses get_heater_cooler_schema with include_name=False
+
+**Phase 3: Feature Integration Tests (After Basic Works)**
+- Files to create (LATER):
+  - `tests/features/test_heater_cooler_with_fan.py`
+  - `tests/features/test_heater_cooler_with_humidity.py`
+  - `tests/features/test_heater_cooler_with_presets.py`
+  - `tests/unit/test_heater_cooler_climate_entity.py`
+
+**How to run (TDD RED-GREEN-REFACTOR cycle):**
+```bash
+# Phase 1: Write tests (should FAIL initially)
+pytest tests/config_flow/test_heater_cooler_config_flow.py -v
+pytest tests/unit/test_heater_cooler_schema.py -v
+
+# Phase 2: Implement code to make tests pass
+# ... make changes to schemas.py, config_flow.py ...
+
+# Phase 3: Verify tests now PASS
+pytest tests/config_flow/test_heater_cooler_config_flow.py -v
+pytest tests/unit/test_heater_cooler_schema.py -v
+
+# Phase 4: Ensure no regressions
+pytest tests/config_flow -v
+pytest tests/unit -v
+```
+
+**Bug Fixes Already Applied (2025-01-06):**
+- ✅ Missing name field in get_heater_cooler_schema() - line 248 config_flow.py
+- ✅ Missing fan_hot_tolerance numeric field in schema - line 690 schemas.py
+- ✅ fan_hot_tolerance_toggle validation error (None vs vol.UNDEFINED) - line 695 schemas.py
+- ✅ Unified fan/humidity schemas to remove duplication
+- ✅ Added translations for fan_hot_tolerance and fan_hot_tolerance_toggle
+- ✅ Updated README.md documentation for both fields
+
+**Acceptance Criteria (UPDATED TDD APPROACH + DATA VALIDATION):**
+
+**Test-Driven Development (TDD):**
+- ✅ All tests written BEFORE implementation (RED phase)
+- ✅ Tests fail initially with clear error messages
+- ✅ Implementation makes tests pass (GREEN phase)
+- ✅ No regressions in existing simple_heater/ac_only tests
+
+**Config Flow - Core Requirements:**
+1. ✅ Flow completes without error - All steps navigate successfully to completion
+2. ✅ Valid configuration is created - Config entry data matches `data-model.md` structure
+3. ✅ Climate entity is created - Verify entity appears in HA with correct entity_id
+
+**Config Flow - Data Structure Validation:**
+- ✅ All required fields from schema are present in saved config
+- ✅ Field types match expected types (entity_id strings, numeric values, booleans)
+- ✅ System-specific fields: `heater`, `cooler`, `target_sensor` are entity_ids
+- ✅ `heat_cool_mode` field exists with correct boolean default
+- ✅ Advanced settings are flattened to top level (tolerances, min_cycle_duration)
+- ✅ `name` field is collected (bug fix 2025-01-06 verified)
+
+**Options Flow - Core Requirements:**
+1. ✅ Flow completes without error - All steps navigate successfully
+2. ✅ Configuration is updated correctly - Modified fields are persisted
+3. ✅ Unmodified fields are preserved - Fields not changed remain intact
+
+**Options Flow - Data Structure Validation:**
+- ✅ `name` field is omitted in options flow
+- ✅ Options flow pre-fills all heater_cooler fields from existing config
+- ✅ System type is displayed but non-editable
+- ✅ Updated config matches `data-model.md` structure after changes
+
+**Field-Specific Validation (Unit Tests):**
+- ✅ Optional entity fields accept empty values (vol.UNDEFINED pattern)
+- ✅ Numeric fields have correct defaults when not provided
+- ✅ Required fields (heater, cooler, sensor) raise validation errors when missing
+- ✅ Validation: same heater/cooler entity produces error
+- ✅ Validation: same heater/sensor entity produces error
+
+**Feature Integration:**
+- ✅ Features step allows toggling features on/off
+- ✅ Enabled features show their configuration steps
+- ✅ Feature settings are saved under correct keys
+- ✅ Feature settings match schema definitions
+
+**Business Logic Validation:**
+- ✅ HeaterCoolerDevice class works correctly with schema
+- ✅ Config flow creates working climate entity
+- ✅ Climate entity has correct HVAC modes for heater_cooler system
+
+**Scope Notes:**
+- ❌ **REMOVED**: E2E test coverage (covered by simple_heater/ac_only E2E tests)
+- ✅ **FOCUS**: Python unit/integration tests for data validation and business logic
+
+**Parallelization**: Can be run in parallel with T006 and T007 if no shared files are edited simultaneously.
 
 T006 — Complete `heat_pump` implementation (Phase 1C) 📉 [REDUCED SCOPE] — [GitHub Issue #416](https://github.com/swingerman/ha-dual-smart-thermostat/issues/416)
 - **SCOPE REDUCTION**: Focus on Python implementation and unit tests only; E2E tests removed from scope
-- Files to edit/create:
-  - `custom_components/dual_smart_thermostat/schemas.py` (complete `get_heat_pump_schema` and `heat_pump_cooling` support)
-  - `custom_components/dual_smart_thermostat/feature_steps/` handlers
-  - Tests: `tests/features/heat_pump/test_config_flow.py`, `tests/features/heat_pump/test_options_flow.py`
-  - **NEW**: `tests/unit/test_heat_pump_climate_entity.py` — Test climate entity generation for heat_pump
-- **REMOVED FROM SCOPE**: E2E Playwright tests (too expensive to maintain)
-- Special notes:
-  - The `heat_pump_cooling` field may be an entity selector (preferred) or a boolean; ensure schema supports entity ids and the options flow offers a selector.
-- Updated Acceptance criteria:
-  - ✅ Contract tests for `heat_pump` pass; `pytest -q` passes locally.
-  - ✅ Python tests validate climate entity structure and behavior.
-  - ✅ `heat_pump_cooling` entity selector functionality works correctly.
-  - ❌ **REMOVED**: E2E test coverage requirement for `heat_pump`.
-- Parallelization: Can run with T005 (different system types), but coordinate on `schemas.py` edits.
+- **Strategy**: Write failing tests FIRST (RED), implement code (GREEN), validate no regressions (REFACTOR)
 
-T007 — Add Python Unit Tests for Climate Entity & Data Structure Validation 🔥 [HIGH PRIORITY] — [GitHub Issue #417](https://github.com/swingerman/ha-dual-smart-thermostat/issues/417)
-- **PRIORITY ELEVATION**: Elevated from medium to HIGH PRIORITY based on refined testing strategy
-- **New Focus**: Comprehensive Python unit tests for business logic and data structure validation
-- Files to create:
-  - `tests/unit/test_climate_entity_generation.py` — **NEW HIGH PRIORITY**: Test actual Home Assistant climate entity creation and configuration
-  - `tests/unit/test_config_entry_data_structure.py` — **NEW HIGH PRIORITY**: Test saved config entry data matches canonical `data-model.md`
-  - `tests/unit/test_system_type_configs.py` — **NEW HIGH PRIORITY**: Test system-specific configurations are applied correctly
-  - `tests/integration/test_integration_behavior.py` — **NEW HIGH PRIORITY**: Test Home Assistant integration behavior
-  - `tests/contracts/test_schemas.py` — tests that load each `get_<system>_schema()` and assert expected keys and types according to `data-model.md`.
-  - `tests/options/test_options_parity.py` — tests verifying the options flow pre-fills saved values and preserves unchanged fields.
-- **Rationale**: E2E tests handle UI journeys; Python tests should handle business logic, data structures, and HA integration behavior
-- Description:
-  - Write failing tests first for each missing contract, then implement the code to pass them (TDD).
-  - Focus on testing actual climate entity generation, not just UI behavior
-  - Validate that saved configuration data matches expected structure
-  - Test system-specific behavior (AC mode, heater mode, etc.)
-- How to run:
-  ```bash
-  # New high-priority tests
-  pytest tests/unit/test_climate_entity_generation.py -v
-  pytest tests/unit/test_config_entry_data_structure.py -v
-  pytest tests/unit/test_system_type_configs.py -v
-  pytest tests/integration/test_integration_behavior.py -v
-  # Existing contract tests
-  pytest tests/contracts -q
-  pytest tests/options -q
+**Files to create/edit:**
+- `custom_components/dual_smart_thermostat/schemas.py` (complete `get_heat_pump_schema` and `heat_pump_cooling` support)
+- `custom_components/dual_smart_thermostat/feature_steps/` handlers
+- Tests: `tests/config_flow/test_heat_pump_config_flow.py`, `tests/config_flow/test_heat_pump_options_flow.py`
+- **NEW**: `tests/unit/test_heat_pump_climate_entity.py` — Test climate entity generation for heat_pump
+- **NEW**: `tests/unit/test_heat_pump_schema.py` — Test schema structure and defaults
+
+**Special Implementation Notes:**
+- The `heat_pump_cooling` field may be an entity selector (preferred) or a boolean
+- Ensure schema supports entity ids and the options flow offers a selector
+- Single `heater` switch is used for both heating and cooling modes
+
+**Acceptance Criteria (TDD APPROACH + DATA VALIDATION):**
+
+**Test-Driven Development (TDD):**
+- ✅ All tests written BEFORE implementation (RED phase)
+- ✅ Tests fail initially with clear error messages
+- ✅ Implementation makes tests pass (GREEN phase)
+- ✅ No regressions in existing system type tests
+
+**Config Flow - Core Requirements:**
+1. ✅ Flow completes without error - All steps navigate successfully to completion
+2. ✅ Valid configuration is created - Config entry data matches `data-model.md` structure
+3. ✅ Climate entity is created - Verify entity appears in HA with correct entity_id
+
+**Config Flow - Data Structure Validation:**
+- ✅ All required fields from schema are present in saved config
+- ✅ Field types match expected types (entity_id strings, numeric values, booleans)
+- ✅ System-specific fields: `heater` (entity_id), `heat_pump_cooling` (entity_id or boolean)
+- ✅ `target_sensor` is entity_id
+- ✅ Advanced settings are flattened to top level (tolerances, min_cycle_duration)
+- ✅ `name` field is collected in config flow
+
+**Options Flow - Core Requirements:**
+1. ✅ Flow completes without error - All steps navigate successfully
+2. ✅ Configuration is updated correctly - Modified fields are persisted
+3. ✅ Unmodified fields are preserved - Fields not changed remain intact
+
+**Options Flow - Data Structure Validation:**
+- ✅ `name` field is omitted in options flow
+- ✅ Options flow pre-fills all heat_pump fields from existing config
+- ✅ System type is displayed but non-editable
+- ✅ Updated config matches `data-model.md` structure after changes
+
+**Field-Specific Validation (Unit Tests):**
+- ✅ `heat_pump_cooling` accepts entity_id (preferred) or boolean
+- ✅ `heat_pump_cooling` entity selector functionality works correctly
+- ✅ Optional entity fields accept empty values (vol.UNDEFINED pattern)
+- ✅ Numeric fields have correct defaults when not provided
+- ✅ Required fields (heater, sensor) raise validation errors when missing
+
+**Feature Integration:**
+- ✅ Features step allows toggling features on/off
+- ✅ Enabled features show their configuration steps
+- ✅ Feature settings are saved under correct keys
+- ✅ Feature settings match schema definitions
+
+**Business Logic Validation:**
+- ✅ HeatPumpDevice class works correctly with schema
+- ✅ Config flow creates working climate entity
+- ✅ Climate entity has correct HVAC modes based on heat_pump_cooling state
+- ✅ Dynamic heat_pump_cooling entity state changes update available HVAC modes
+
+**Scope Notes:**
+- ❌ **REMOVED**: E2E test coverage (covered by simple_heater/ac_only E2E tests)
+- ✅ **FOCUS**: Python unit/integration tests for data validation and business logic
+
+**Parallelization**: Can run with T005 (different system types), but coordinate on `schemas.py` edits.
+
+T007 — ~~Add Python Unit Tests for Climate Entity & Data Structure Validation~~ ❌ **REMOVED - DUPLICATE** — ~~[GitHub Issue #417](https://github.com/swingerman/ha-dual-smart-thermostat/issues/417)~~
+- **STATUS**: ❌ **TASK REMOVED** - Acceptance criteria merged into T005/T006
+- **RATIONALE**: T005 and T006 already include all required test coverage:
+  - Climate entity generation tests (covered in T005/T006 Business Logic Validation)
+  - Config entry data structure tests (covered in T005/T006 Data Structure Validation)
+  - System type configuration tests (covered in T005/T006 acceptance criteria)
+  - Contract tests and options parity tests (covered in T005/T006 Field-Specific Validation)
+- **ACTION**: Tests will be created as part of T005 (heater_cooler) and T006 (heat_pump) implementation
+- **GITHUB ISSUE**: Should be closed or updated to reference T005/T006
+
+T007A — Feature Interaction & HVAC Mode Testing 🔥 [NEW - CRITICAL FOR RELEASE] — [GitHub Issue #436](https://github.com/swingerman/ha-dual-smart-thermostat/issues/436)
+- **PRIORITY**: 🔥 **HIGH PRIORITY** - Critical for feature completeness
+- **DEPENDENCY**: Must complete AFTER T005/T006 (requires all system types working)
+- **RATIONALE**: Features affect HVAC modes, which affect other features. This creates a cascade:
   ```
-- Acceptance criteria:
-  - ✅ Climate entity structure tests validate actual HA entity attributes per system type
-  - ✅ Config entry data structure tests ensure saved data matches `data-model.md`
-  - ✅ System type configuration tests validate system-specific behavior
-  - ✅ Integration behavior tests validate HA core integration
-  - ✅ Contract tests fail initially (RED), then after implementation pass (GREEN)
-- Parallelization: [P] with T004 (different files)
+  System Type + Core Settings → Base HVAC modes
+      ↓
+  Fan Feature → Adds HVACMode.FAN_ONLY
+      ↓
+  Humidity Feature → Adds HVACMode.DRY
+      ↓
+  Openings Feature → Needs available HVAC modes for scope configuration
+      ↓
+  Presets Feature → Needs ALL enabled features to configure properly
+  ```
+
+**Why Ordering Matters:**
+- **Openings** need to know which HVAC modes exist (heat, cool, fan_only, dry, heat_cool)
+- **Presets** need to know:
+  - Which HVAC modes are available (from all previous features)
+  - Which openings exist (to reference them with validation)
+  - If humidity is enabled (to include humidity bounds)
+  - If floor_heating is enabled (to include floor temp bounds)
+  - If heat_cool_mode is true (to use temp_low/temp_high vs single temperature)
+
+**Implementation Strategy:**
+Break into sub-tasks by feature layer:
+
+**Phase 1: Single Feature + System Type (T007A-1)**
+- Test fan feature adds FAN_ONLY mode (heater_cooler + fan, heat_pump + fan)
+- Test humidity feature adds DRY mode (all system types + humidity)
+- Test floor_heating works with compatible system types (simple_heater, heater_cooler, heat_pump - NOT ac_only)
+- Verify feature availability per system type matches schemas.py:458-478
+
+**Phase 2: Openings + HVAC Modes (T007A-2)**
+- Test openings scope configuration with different HVAC mode combinations
+- Test openings work when fan adds FAN_ONLY mode
+- Test openings work when humidity adds DRY mode
+- Test openings_scope field accepts all available HVAC modes for the configuration
+
+**Phase 3: Presets + All Features (T007A-3)**
+- Test presets with heat_cool_mode=True uses temp_low/temp_high
+- Test presets with heat_cool_mode=False uses single temperature
+- Test presets with humidity enabled includes humidity bounds
+- Test presets with floor_heating enabled includes floor temp bounds (min_floor_temp, max_floor_temp)
+- Test presets with openings enabled validates opening_refs
+- Test preset validation error when referencing non-configured opening
+
+**Files to create/edit:**
+- `tests/features/test_feature_hvac_mode_interactions.py` — Test HVAC mode additions
+- `tests/features/test_openings_with_hvac_modes.py` — Test openings scope with various modes
+- `tests/features/test_presets_with_all_features.py` — Test presets respecting all feature combinations
+- `tests/integration/test_complete_feature_flows.py` — End-to-end feature combination tests
+
+**How to run:**
+```bash
+# Phase 1: Feature + System Type
+pytest tests/features/test_feature_hvac_mode_interactions.py -v
+
+# Phase 2: Openings interactions
+pytest tests/features/test_openings_with_hvac_modes.py -v
+
+# Phase 3: Presets interactions
+pytest tests/features/test_presets_with_all_features.py -v
+
+# Full suite
+pytest tests/features -v
+pytest tests/integration -v
+```
+
+**Acceptance Criteria (Following Universal Template):**
+
+**Test-Driven Development (TDD):**
+- ✅ All tests written BEFORE implementation (RED phase)
+- ✅ Tests fail initially with clear error messages
+- ✅ Implementation makes tests pass (GREEN phase)
+- ✅ No regressions in T005/T006 system type tests
+
+**Feature Interaction - Core Requirements:**
+1. ✅ **Fan feature adds FAN_ONLY mode** - Verified across all compatible system types
+2. ✅ **Humidity feature adds DRY mode** - Verified across all system types
+3. ✅ **Floor heating restriction** - Works with heater-based systems, blocked/hidden for ac_only
+4. ✅ **Feature availability per system type** - Matches schemas.py definitions
+
+**Openings + HVAC Modes:**
+- ✅ Openings scope accepts all available HVAC modes for current configuration
+- ✅ Openings configuration appears BEFORE presets in flow order
+- ✅ Openings work correctly when FAN_ONLY mode added by fan feature
+- ✅ Openings work correctly when DRY mode added by humidity feature
+
+**Presets + All Features (Most Complex):**
+- ✅ Presets appear LAST in feature configuration order (after all other features)
+- ✅ Presets use temp_low/temp_high when heat_cool_mode=True
+- ✅ Presets use single temperature when heat_cool_mode=False
+- ✅ Presets include humidity bounds ONLY when humidity feature enabled
+- ✅ Presets include floor temp bounds ONLY when floor_heating feature enabled
+- ✅ Presets validate opening_refs against configured openings
+- ✅ Preset validation fails when referencing non-existent opening
+- ✅ Presets configuration form adapts to all enabled features
+
+**Data Structure Validation:**
+- ✅ Feature settings saved under correct keys in data-model.md structure
+- ✅ HVAC modes correctly populated based on enabled features
+- ✅ Climate entity exposes correct HVAC modes based on feature combination
+
+**Business Logic Validation:**
+- ✅ Climate entity switches modes correctly with fan feature
+- ✅ Climate entity handles humidity/dry mode correctly
+- ✅ Openings behavior respects configured HVAC mode scope
+- ✅ Presets apply correct settings based on all enabled features
+
+**Quality Gates:**
+- ✅ All code must pass linting checks
+- ✅ All unit tests must pass
+- ✅ All integration tests must pass
+- ✅ No regressions in existing system type tests
+
+**Parallelization**: Cannot run in parallel with T005/T006 - requires them complete first
 
 T008 — Normalize collected_config keys and constants — [GitHub Issue #418](https://github.com/swingerman/ha-dual-smart-thermostat/issues/418)
 - Files to edit:
@@ -243,7 +591,8 @@ T009 — Add `models.py` dataclasses [P] — [GitHub Issue #419](https://github.
   - `tests/unit/test_models.py` covers serialization of at least one sample config per system type and passes.
 - Parallelization: [P]
 
-T010 — Perform test reorganization (REORG) [P] — [GitHub Issue #420](https://github.com/swingerman/ha-dual-smart-thermostat/issues/420)
+T010 — Perform test reorganization (REORG) [P] ⚪ **OPTIONAL** — [GitHub Issue #420](https://github.com/swingerman/ha-dual-smart-thermostat/issues/420)
+- **PRIORITY**: ⚪ **OPTIONAL** - Nice-to-have, not blocking release
 - Files to create:
   - `specs/001-develop-config-and/REORG.md`
 - Steps (PoC then single commit):
@@ -254,9 +603,11 @@ T010 — Perform test reorganization (REORG) [P] — [GitHub Issue #420](https:/
   5. Run `pytest -q` and fix regressions.
 - Acceptance criteria:
   - New `tests/` layout exists, test imports updated, full test-suite passes locally.
+- **Release Impact**: None - Can be done post-release for better maintainability
 - Parallelization: [P] but coordinate with any test-editing PRs.
 
-T011 — Investigate schema duplication (const vs schemas) (Phase 1C-1) — [GitHub Issue #421](https://github.com/swingerman/ha-dual-smart-thermostat/issues/421)
+T011 — Investigate schema duplication (const vs schemas) (Phase 1C-1) ⚪ **OPTIONAL** — [GitHub Issue #421](https://github.com/swingerman/ha-dual-smart-thermostat/issues/421)
+- **PRIORITY**: ⚪ **OPTIONAL** - Nice-to-have, not blocking release
 - Files to create/edit:
   - `specs/001-develop-config-and/schema-consolidation-proposal.md` (if not already present)
   - PoC: `custom_components/dual_smart_thermostat/metadata.py`
@@ -269,6 +620,7 @@ T011 — Investigate schema duplication (const vs schemas) (Phase 1C-1) — [Git
 - Acceptance criteria:
   - Proposal file present with recommended option and risk/effort estimates.
   - PoC passes contract tests and does not change persisted keys.
+- **Release Impact**: None - Only do if duplication becomes painful during T005/T006/T008
 - Parallelization: [P]
 
 T012 — Polish documentation & release prep — [GitHub Issue #422](https://github.com/swingerman/ha-dual-smart-thermostat/issues/422)
@@ -285,20 +637,48 @@ T012 — Polish documentation & release prep — [GitHub Issue #422](https://git
 
 ---
 
-Task Ordering and dependency notes (UPDATED)
+Task Ordering and dependency notes (UPDATED 2025-01-06)
 - ✅ E2E scaffold (T001), Playwright tests (T002), and complete E2E implementation (T003) COMPLETED — **EXCEEDED ORIGINAL SCOPE**.
-- **CURRENT HIGH PRIORITIES**: 
-  1. 🔥 **T004** (Remove Advanced option) — Clean up codebase before heavy development
-  2. 🔥 **T007** (Python unit tests) — **ELEVATED PRIORITY** for business logic validation
-- **MEDIUM PRIORITIES**: T008 (normalize keys) → T005/T006 (complete system types with Python-first approach) → T009 (models.py)
-- **LOW PRIORITIES**: T010 (test reorg), T011 (schema consolidation), T012 (documentation)
-- **SCOPE REDUCTIONS**: T005/T006 no longer require E2E tests; T010/T011 reduced to nice-to-have status
+- ❌ T007 REMOVED — Duplicate of T005/T006 acceptance criteria
+- 🆕 T007A ADDED — Feature interaction & HVAC mode testing (critical for release)
 
-Updated Parallel execution examples
-- **Immediate Parallel Group** 🔥: {T004, T007} — High priority, different files
-- **Medium-term Parallel Group**: {T005, T006, T008, T009} — Coordinate on `schemas.py` edits
-- **Final Parallel Group**: {T010, T011, T012} — Low priority polish tasks
-- **Recommended Sequential Path**: T004 → T007 → T008 → {T005, T006} → T009 → T012
+**CURRENT PRIORITIES** (Revised):
+1. 🔥 **T004** (Remove Advanced option) — Clean up codebase before heavy development
+2. 🔥 **T005** (Complete heater_cooler with TDD) — Includes all unit/integration tests
+3. 🔥 **T006** (Complete heat_pump with TDD) — Includes all unit/integration tests
+4. 🔥 **T007A** (Feature interaction testing) — **NEW: CRITICAL** - Test feature combinations & HVAC modes
+5. ✅ **T008** (Normalize keys) — Clean up after system type implementations
+6. ✅ **T009** (models.py) — Add type safety with dataclasses
+7. ✅ **T012** (Documentation & release prep) — Essential for release
+8. ⚪ **T010** (Test reorg) — **OPTIONAL** - Not blocking release
+9. ⚪ **T011** (Schema consolidation) — **OPTIONAL** - Not blocking release
+
+**Updated Parallel execution examples:**
+- **Phase 1** 🔥: T004 (Advanced option removal) — Do first, blocks nothing
+- **Phase 2** 🔥: {T005, T006} — Parallel implementation, coordinate on `schemas.py` edits
+- **Phase 3** 🔥: T007A (Feature interactions) — MUST complete after T005/T006
+- **Phase 4** ✅: T008 (Normalize keys after learning from T005/T006/T007A)
+- **Phase 5** ✅: {T009, T012} — Parallel, different files
+- **Phase 6** ⚪: {T010, T011} — **OPTIONAL** - Only if time permits
+
+**Recommended Sequential Path (Critical Path to Release):**
+```
+T004 → {T005, T006} → T007A → T008 → {T009, T012} → RELEASE
+       (parallel)      ↑               (parallel)
+                   [NEW: Critical
+                    for features]
+```
+
+**Why T007A is Critical:**
+- Features affect HVAC modes (fan→FAN_ONLY, humidity→DRY)
+- HVAC modes affect openings (scope configuration)
+- All features affect presets (temp fields, humidity, floor, opening refs)
+- Without T007A, feature combinations may break in production
+
+**Optional Post-Release:**
+```
+T010 (test reorg) and T011 (schema consolidation) can be done after release if needed
+```
 
 Appendix — Helpful Commands
 - Run focused tests:

--- a/tests/config_flow/test_e2e_ac_only_persistence.py
+++ b/tests/config_flow/test_e2e_ac_only_persistence.py
@@ -1,0 +1,219 @@
+"""End-to-end tests for AC_ONLY system type: config flow → options flow persistence.
+
+This test validates the complete lifecycle for ac_only systems:
+1. User completes config flow with initial settings
+2. User opens options flow and sees the correct values pre-filled
+3. User changes some settings in options flow
+4. Changes persist correctly (in entry.options)
+5. Original values are preserved (in entry.data)
+6. Reopening options flow shows the updated values
+"""
+
+from homeassistant.const import CONF_NAME
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COOLER,
+    CONF_FAN,
+    CONF_FAN_MODE,
+    CONF_FAN_ON_WITH_AC,
+    CONF_HOT_TOLERANCE,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    DOMAIN,
+    SYSTEM_TYPE_AC_ONLY,
+)
+
+
+@pytest.mark.asyncio
+async def test_ac_only_full_config_then_options_flow_persistence(hass):
+    """Test complete AC_ONLY flow: config → options → verify persistence.
+
+    Tests the ac_only system type with fan feature and tolerance changes.
+    """
+    from custom_components.dual_smart_thermostat.config_flow import ConfigFlowHandler
+    from custom_components.dual_smart_thermostat.options_flow import OptionsFlowHandler
+
+    # ===== STEP 1: Complete config flow =====
+    config_flow = ConfigFlowHandler()
+    config_flow.hass = hass
+
+    # Start config flow - user selects AC only
+    result = await config_flow.async_step_user({CONF_SYSTEM_TYPE: SYSTEM_TYPE_AC_ONLY})
+
+    # Fill in basic AC config
+    initial_config = {
+        CONF_NAME: "AC Only Test",
+        CONF_SENSOR: "sensor.room_temp",
+        CONF_COOLER: "switch.ac",
+        CONF_HOT_TOLERANCE: 0.5,
+    }
+    result = await config_flow.async_step_basic_ac_only(initial_config)
+
+    # Enable fan feature
+    result = await config_flow.async_step_features(
+        {
+            "configure_fan": True,
+        }
+    )
+
+    # Configure fan for AC
+    initial_fan_config = {
+        CONF_FAN: "switch.fan",
+        CONF_FAN_MODE: False,
+        CONF_FAN_ON_WITH_AC: True,  # Fan runs with AC
+    }
+    result = await config_flow.async_step_fan(initial_fan_config)
+
+    # Flow should complete
+    assert result["type"] == "create_entry"
+    assert result["title"] == "AC Only Test"
+
+    # ===== STEP 2: Verify initial config entry =====
+    created_data = result["data"]
+
+    # Check no transient flags saved
+    assert "configure_fan" not in created_data
+    assert "features_shown" not in created_data
+
+    # Check actual config is saved
+    assert created_data[CONF_NAME] == "AC Only Test"
+    assert created_data[CONF_SYSTEM_TYPE] == SYSTEM_TYPE_AC_ONLY
+    assert created_data[CONF_COOLER] == "switch.ac"
+    assert created_data[CONF_HOT_TOLERANCE] == 0.5
+    assert created_data[CONF_FAN] == "switch.fan"
+    assert created_data[CONF_FAN_MODE] is False
+    assert created_data[CONF_FAN_ON_WITH_AC] is True
+
+    # ===== STEP 3: Create MockConfigEntry =====
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=created_data,
+        options={},
+        title="AC Only Test",
+    )
+    config_entry.add_to_hass(hass)
+
+    # ===== STEP 4: Open options flow and verify pre-filled values =====
+    options_flow = OptionsFlowHandler(config_entry)
+    options_flow.hass = hass
+
+    # Navigate to basic step
+    result = await options_flow.async_step_init()
+    result = await options_flow.async_step_init({CONF_SYSTEM_TYPE: SYSTEM_TYPE_AC_ONLY})
+
+    # Should show basic form with hot tolerance pre-filled
+    assert result["type"] == "form"
+    assert result["step_id"] == "basic"
+
+    # ===== STEP 5: Change hot tolerance =====
+    # Note: Tolerances are in advanced_settings, so we focus on core flow
+    updated_basic_config = {
+        CONF_SENSOR: "sensor.room_temp",
+        CONF_COOLER: "switch.ac",
+        CONF_HOT_TOLERANCE: 0.8,  # CHANGE: was 0.5
+    }
+    result = await options_flow.async_step_basic(updated_basic_config)
+
+    # Should go to features
+    assert result["type"] == "form"
+    assert result["step_id"] == "features"
+
+    # Check fan toggle is pre-checked
+    features_schema = result["data_schema"].schema
+    configure_fan_default = None
+    for key in features_schema:
+        if str(key) == "configure_fan":
+            configure_fan_default = (
+                key.default() if callable(key.default) else key.default
+            )
+            break
+
+    assert configure_fan_default is True, "Fan toggle should be pre-checked!"
+
+    # Enable fan to modify its settings
+    result = await options_flow.async_step_features({"configure_fan": True})
+
+    # Should show fan options
+    assert result["type"] == "form"
+    assert result["step_id"] == "fan_options"
+
+    # Verify fan settings are pre-filled
+    fan_schema = result["data_schema"].schema
+    fan_defaults = {}
+    for key in fan_schema:
+        key_str = str(key)
+        if hasattr(key, "default"):
+            default_val = key.default() if callable(key.default) else key.default
+            fan_defaults[key_str] = default_val
+
+    assert fan_defaults.get(CONF_FAN_MODE) is False
+    assert fan_defaults.get(CONF_FAN_ON_WITH_AC) is True
+
+    # Change fan settings
+    result = await options_flow.async_step_fan_options(
+        {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: True,  # CHANGE: was False
+            CONF_FAN_ON_WITH_AC: False,  # CHANGE: was True
+        }
+    )
+
+    # Should complete
+    assert result["type"] == "create_entry"
+
+    # ===== STEP 6: Verify persistence =====
+    updated_data = result["data"]
+
+    # Check no transient flags
+    assert "configure_fan" not in updated_data
+    assert "features_shown" not in updated_data
+
+    # Check changed values
+    assert updated_data[CONF_HOT_TOLERANCE] == 0.8
+    assert updated_data[CONF_FAN_MODE] is True
+    assert updated_data[CONF_FAN_ON_WITH_AC] is False
+
+    # Check preserved values
+    assert updated_data[CONF_NAME] == "AC Only Test"
+    assert updated_data[CONF_COOLER] == "switch.ac"
+    assert updated_data[CONF_FAN] == "switch.fan"
+
+    # ===== STEP 7: Reopen and verify updated values shown =====
+    config_entry_after = MockConfigEntry(
+        domain=DOMAIN,
+        data=created_data,  # Original unchanged
+        options={
+            CONF_HOT_TOLERANCE: 0.8,
+            CONF_FAN_MODE: True,
+            CONF_FAN_ON_WITH_AC: False,
+        },
+        title="AC Only Test",
+    )
+    config_entry_after.add_to_hass(hass)
+
+    options_flow2 = OptionsFlowHandler(config_entry_after)
+    options_flow2.hass = hass
+
+    result = await options_flow2.async_step_init()
+    result = await options_flow2.async_step_init(
+        {CONF_SYSTEM_TYPE: SYSTEM_TYPE_AC_ONLY}
+    )
+
+    # Navigate to fan to verify updated values
+    result = await options_flow2.async_step_basic({})
+    result = await options_flow2.async_step_features({"configure_fan": True})
+
+    fan_schema2 = result["data_schema"].schema
+    fan_defaults2 = {}
+    for key in fan_schema2:
+        key_str = str(key)
+        if hasattr(key, "default"):
+            default_val = key.default() if callable(key.default) else key.default
+            fan_defaults2[key_str] = default_val
+
+    assert fan_defaults2.get(CONF_FAN_MODE) is True, "Updated fan_mode should be shown!"
+    assert (
+        fan_defaults2.get(CONF_FAN_ON_WITH_AC) is False
+    ), "Updated fan_on_with_ac should be shown!"

--- a/tests/config_flow/test_e2e_heater_cooler_persistence.py
+++ b/tests/config_flow/test_e2e_heater_cooler_persistence.py
@@ -1,0 +1,337 @@
+"""End-to-end tests for HEATER_COOLER system type: config flow → options flow persistence.
+
+This test validates the complete lifecycle for heater_cooler systems:
+1. User completes config flow with initial settings
+2. User opens options flow and sees the correct values pre-filled
+3. User changes some settings in options flow
+4. Changes persist correctly (in entry.options)
+5. Original values are preserved (in entry.data)
+6. Reopening options flow shows the updated values
+
+Note: Similar E2E tests should exist for all system types:
+- test_e2e_simple_heater_persistence.py
+- test_e2e_ac_only_persistence.py
+- test_e2e_heat_pump_persistence.py (TODO: when heat pump is implemented)
+- test_e2e_dual_stage_persistence.py (TODO: if needed)
+- test_e2e_floor_heating_persistence.py (TODO: if needed)
+"""
+
+from homeassistant.const import CONF_NAME
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COOLER,
+    CONF_FAN,
+    CONF_FAN_AIR_OUTSIDE,
+    CONF_FAN_HOT_TOLERANCE,
+    CONF_FAN_MODE,
+    CONF_FAN_ON_WITH_AC,
+    CONF_HEATER,
+    CONF_HUMIDITY_SENSOR,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    DOMAIN,
+    SYSTEM_TYPE_HEATER_COOLER,
+)
+
+
+@pytest.mark.asyncio
+async def test_heater_cooler_full_config_then_options_flow_persistence(hass):
+    """Test complete HEATER_COOLER flow: config → options → verify persistence.
+
+    This is the test that would have caught the options flow persistence bug.
+    Tests the heater_cooler system type with fan feature.
+    """
+    from custom_components.dual_smart_thermostat.config_flow import ConfigFlowHandler
+    from custom_components.dual_smart_thermostat.options_flow import OptionsFlowHandler
+
+    # ===== STEP 1: Complete config flow =====
+    config_flow = ConfigFlowHandler()
+    config_flow.hass = hass
+
+    # Start config flow
+    result = await config_flow.async_step_user(
+        {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+    )
+
+    # Fill in basic heater/cooler config
+    result = await config_flow.async_step_heater_cooler(
+        {
+            CONF_NAME: "Test Thermostat",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+    )
+
+    # Enable fan feature
+    result = await config_flow.async_step_features(
+        {
+            "configure_fan": True,
+        }
+    )
+
+    # Configure fan with specific settings
+    initial_fan_config = {
+        CONF_FAN: "switch.fan",
+        CONF_FAN_MODE: True,
+        CONF_FAN_ON_WITH_AC: True,
+        CONF_FAN_AIR_OUTSIDE: True,
+        CONF_FAN_HOT_TOLERANCE: 0.5,
+    }
+    result = await config_flow.async_step_fan(initial_fan_config)
+
+    # Flow should complete
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Test Thermostat"
+
+    # ===== STEP 2: Verify initial config entry =====
+    created_data = result["data"]
+
+    # Check no transient flags saved
+    assert "configure_fan" not in created_data, "Transient flags should not be saved!"
+    assert "features_shown" not in created_data, "Transient flags should not be saved!"
+
+    # Check actual config is saved
+    assert created_data[CONF_NAME] == "Test Thermostat"
+    assert created_data[CONF_SYSTEM_TYPE] == SYSTEM_TYPE_HEATER_COOLER
+    assert created_data[CONF_FAN] == "switch.fan"
+    assert created_data[CONF_FAN_MODE] is True
+    assert created_data[CONF_FAN_ON_WITH_AC] is True
+    assert created_data[CONF_FAN_AIR_OUTSIDE] is True
+    assert created_data[CONF_FAN_HOT_TOLERANCE] == 0.5
+
+    # ===== STEP 3: Create MockConfigEntry to simulate HA storage =====
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=created_data,
+        options={},  # Initially empty, as HA would have
+        title="Test Thermostat",
+    )
+    config_entry.add_to_hass(hass)
+
+    # ===== STEP 4: Open options flow and verify pre-filled values =====
+    options_flow = OptionsFlowHandler(config_entry)
+    options_flow.hass = hass
+
+    # Step through options flow to get to fan configuration
+    result = await options_flow.async_step_init()
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+
+    result = await options_flow.async_step_init(
+        {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "basic"
+
+    result = await options_flow.async_step_basic({})
+    assert result["type"] == "form"
+    assert result["step_id"] == "features"
+
+    # Check that fan toggle is pre-checked (because fan is configured)
+    features_schema = result["data_schema"].schema
+    configure_fan_field = None
+    for key in features_schema:
+        if str(key) == "configure_fan":
+            configure_fan_field = key
+            break
+
+    assert configure_fan_field is not None, "configure_fan field should exist"
+    configure_fan_default = (
+        configure_fan_field.default()
+        if callable(configure_fan_field.default)
+        else configure_fan_field.default
+    )
+    assert configure_fan_default is True, "Fan toggle should be pre-checked!"
+
+    # Continue to fan options
+    result = await options_flow.async_step_features(
+        {
+            "configure_fan": True,
+        }
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "fan_options"
+
+    # Verify fan options are pre-filled with original values
+    fan_schema = result["data_schema"].schema
+    fan_defaults = {}
+    for key in fan_schema:
+        key_str = str(key)
+        if hasattr(key, "default"):
+            default_val = key.default() if callable(key.default) else key.default
+            fan_defaults[key_str] = default_val
+
+    # These should match the initial config
+    assert fan_defaults.get(CONF_FAN) == "switch.fan"
+    assert fan_defaults.get(CONF_FAN_MODE) is True
+    assert fan_defaults.get(CONF_FAN_ON_WITH_AC) is True
+    assert fan_defaults.get(CONF_FAN_AIR_OUTSIDE) is True
+    assert fan_defaults.get(CONF_FAN_HOT_TOLERANCE) == 0.5
+
+    # ===== STEP 5: Make changes to fan settings =====
+    updated_fan_config = {
+        CONF_FAN: "switch.fan",  # Keep same
+        CONF_FAN_MODE: False,  # CHANGE: was True
+        CONF_FAN_ON_WITH_AC: False,  # CHANGE: was True
+        CONF_FAN_AIR_OUTSIDE: False,  # CHANGE: was True
+        CONF_FAN_HOT_TOLERANCE: 0.8,  # CHANGE: was 0.5
+    }
+    result = await options_flow.async_step_fan_options(updated_fan_config)
+
+    # Should complete the options flow
+    assert result["type"] == "create_entry"
+
+    # ===== STEP 6: Verify persistence in entry =====
+    # The entry should now have the updated values in .options
+    updated_entry_data = result["data"]
+
+    # Check no transient flags saved
+    assert (
+        "configure_fan" not in updated_entry_data
+    ), "Transient flags should not be saved!"
+    assert (
+        "features_shown" not in updated_entry_data
+    ), "Transient flags should not be saved!"
+    assert (
+        "fan_options_shown" not in updated_entry_data
+    ), "Transient flags should not be saved!"
+
+    # Check changed values are in the result
+    assert updated_entry_data[CONF_FAN_MODE] is False, "Changed value should persist"
+    assert (
+        updated_entry_data[CONF_FAN_ON_WITH_AC] is False
+    ), "Changed value should persist"
+    assert (
+        updated_entry_data[CONF_FAN_AIR_OUTSIDE] is False
+    ), "Changed value should persist"
+    assert (
+        updated_entry_data[CONF_FAN_HOT_TOLERANCE] == 0.8
+    ), "Changed value should persist"
+
+    # Check unchanged values are preserved
+    assert updated_entry_data[CONF_NAME] == "Test Thermostat"
+    assert updated_entry_data[CONF_SYSTEM_TYPE] == SYSTEM_TYPE_HEATER_COOLER
+    assert updated_entry_data[CONF_FAN] == "switch.fan"
+    assert updated_entry_data[CONF_HEATER] == "switch.heater"
+    assert updated_entry_data[CONF_COOLER] == "switch.cooler"
+
+    # ===== STEP 7: Reopen options flow and verify updated values are shown =====
+    # Simulate what happens when user reopens options flow after changes
+    # Update the mock entry to have the options set (as HA would)
+    config_entry_after_update = MockConfigEntry(
+        domain=DOMAIN,
+        data=created_data,  # Original data unchanged
+        options=updated_fan_config,  # Options contains the changes
+        title="Test Thermostat",
+    )
+    config_entry_after_update.add_to_hass(hass)
+
+    options_flow2 = OptionsFlowHandler(config_entry_after_update)
+    options_flow2.hass = hass
+
+    # Navigate to fan options again
+    result = await options_flow2.async_step_init()
+    result = await options_flow2.async_step_init(
+        {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+    )
+    result = await options_flow2.async_step_basic({})
+    result = await options_flow2.async_step_features({"configure_fan": True})
+
+    # Verify the UPDATED values are now shown as defaults
+    fan_schema2 = result["data_schema"].schema
+    fan_defaults2 = {}
+    for key in fan_schema2:
+        key_str = str(key)
+        if hasattr(key, "default"):
+            default_val = key.default() if callable(key.default) else key.default
+            fan_defaults2[key_str] = default_val
+
+    # These should match the UPDATED config from options flow
+    assert fan_defaults2.get(CONF_FAN_MODE) is False, "Updated value should be shown!"
+    assert (
+        fan_defaults2.get(CONF_FAN_ON_WITH_AC) is False
+    ), "Updated value should be shown!"
+    assert (
+        fan_defaults2.get(CONF_FAN_AIR_OUTSIDE) is False
+    ), "Updated value should be shown!"
+    assert (
+        fan_defaults2.get(CONF_FAN_HOT_TOLERANCE) == 0.8
+    ), "Updated value should be shown!"
+
+
+@pytest.mark.asyncio
+async def test_heater_cooler_options_flow_preserves_unmodified_fields(hass):
+    """Test that HEATER_COOLER options flow preserves fields the user didn't change.
+
+    This validates that partial updates work correctly when only modifying
+    one feature (fan) while preserving another (humidity).
+    """
+    from custom_components.dual_smart_thermostat.options_flow import OptionsFlowHandler
+
+    # Create entry with both heater and humidity configured
+    initial_data = {
+        CONF_NAME: "Test",
+        CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+        CONF_SENSOR: "sensor.temp",
+        CONF_HEATER: "switch.heater",
+        CONF_COOLER: "switch.cooler",
+        CONF_FAN: "switch.fan",
+        CONF_FAN_MODE: True,
+        CONF_HUMIDITY_SENSOR: "sensor.humidity",
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=initial_data,
+        options={},
+        title="Test",
+    )
+    config_entry.add_to_hass(hass)
+
+    options_flow = OptionsFlowHandler(config_entry)
+    options_flow.hass = hass
+
+    # Navigate through options flow and only modify fan, not humidity
+    result = await options_flow.async_step_init()
+    result = await options_flow.async_step_init(
+        {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+    )
+    result = await options_flow.async_step_basic({})
+    result = await options_flow.async_step_features(
+        {
+            "configure_fan": True,  # Only configure fan, not humidity
+        }
+    )
+
+    # Change fan mode
+    result = await options_flow.async_step_fan_options(
+        {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: False,  # Changed from True
+        }
+    )
+
+    # Since humidity is configured, it will show humidity options
+    # Skip through it without changes
+    if result["type"] == "form" and result["step_id"] == "humidity_options":
+        result = await options_flow.async_step_humidity_options({})
+
+    # Now should complete
+    assert result["type"] == "create_entry"
+
+    updated_data = result["data"]
+
+    # Fan mode should be changed
+    assert updated_data[CONF_FAN_MODE] is False
+
+    # Humidity sensor should be PRESERVED even though we didn't configure it
+    assert (
+        updated_data.get(CONF_HUMIDITY_SENSOR) == "sensor.humidity"
+    ), "Unmodified humidity sensor should be preserved!"
+
+    # All other fields should be preserved
+    assert updated_data[CONF_HEATER] == "switch.heater"
+    assert updated_data[CONF_COOLER] == "switch.cooler"

--- a/tests/config_flow/test_e2e_simple_heater_persistence.py
+++ b/tests/config_flow/test_e2e_simple_heater_persistence.py
@@ -1,0 +1,199 @@
+"""End-to-end tests for SIMPLE_HEATER system type: config flow → options flow persistence.
+
+This test validates the complete lifecycle for simple_heater systems:
+1. User completes config flow with initial settings
+2. User opens options flow and sees the correct values pre-filled
+3. User changes some settings in options flow
+4. Changes persist correctly (in entry.options)
+5. Original values are preserved (in entry.data)
+6. Reopening options flow shows the updated values
+"""
+
+from homeassistant.const import CONF_NAME
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COLD_TOLERANCE,
+    CONF_FAN,
+    CONF_FAN_MODE,
+    CONF_HEATER,
+    CONF_HOT_TOLERANCE,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    DOMAIN,
+    SYSTEM_TYPE_SIMPLE_HEATER,
+)
+
+
+@pytest.mark.asyncio
+async def test_simple_heater_full_config_then_options_flow_persistence(hass):
+    """Test complete SIMPLE_HEATER flow: config → options → verify persistence.
+
+    Tests the simple_heater system type with fan feature and tolerance changes.
+    """
+    from custom_components.dual_smart_thermostat.config_flow import ConfigFlowHandler
+    from custom_components.dual_smart_thermostat.options_flow import OptionsFlowHandler
+
+    # ===== STEP 1: Complete config flow =====
+    config_flow = ConfigFlowHandler()
+    config_flow.hass = hass
+
+    # Start config flow - user selects simple heater
+    result = await config_flow.async_step_user(
+        {CONF_SYSTEM_TYPE: SYSTEM_TYPE_SIMPLE_HEATER}
+    )
+
+    # Fill in basic simple heater config
+    initial_config = {
+        CONF_NAME: "Simple Heater Test",
+        CONF_SENSOR: "sensor.room_temp",
+        CONF_HEATER: "switch.heater",
+        CONF_COLD_TOLERANCE: 0.5,
+        CONF_HOT_TOLERANCE: 0.3,
+    }
+    result = await config_flow.async_step_basic(initial_config)
+
+    # Enable fan feature
+    result = await config_flow.async_step_features(
+        {
+            "configure_fan": True,
+        }
+    )
+
+    # Configure fan
+    initial_fan_config = {
+        CONF_FAN: "switch.fan",
+        CONF_FAN_MODE: False,  # Simple heater with fan mode off
+    }
+    result = await config_flow.async_step_fan(initial_fan_config)
+
+    # Flow should complete
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Simple Heater Test"
+
+    # ===== STEP 2: Verify initial config entry =====
+    created_data = result["data"]
+
+    # Check no transient flags saved
+    assert "configure_fan" not in created_data
+    assert "features_shown" not in created_data
+
+    # Check actual config is saved
+    assert created_data[CONF_NAME] == "Simple Heater Test"
+    assert created_data[CONF_SYSTEM_TYPE] == SYSTEM_TYPE_SIMPLE_HEATER
+    assert created_data[CONF_HEATER] == "switch.heater"
+    assert created_data[CONF_COLD_TOLERANCE] == 0.5
+    assert created_data[CONF_HOT_TOLERANCE] == 0.3
+    assert created_data[CONF_FAN] == "switch.fan"
+    assert created_data[CONF_FAN_MODE] is False
+
+    # ===== STEP 3: Create MockConfigEntry =====
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=created_data,
+        options={},
+        title="Simple Heater Test",
+    )
+    config_entry.add_to_hass(hass)
+
+    # ===== STEP 4: Open options flow and verify pre-filled values =====
+    options_flow = OptionsFlowHandler(config_entry)
+    options_flow.hass = hass
+
+    # Navigate to basic step
+    result = await options_flow.async_step_init()
+    result = await options_flow.async_step_init(
+        {CONF_SYSTEM_TYPE: SYSTEM_TYPE_SIMPLE_HEATER}
+    )
+
+    # Should show basic form with tolerances pre-filled
+    assert result["type"] == "form"
+    assert result["step_id"] == "basic"
+
+    # ===== STEP 5: Change tolerance settings =====
+    # Note: Tolerances are in advanced_settings, so we just test the core flow
+    updated_basic_config = {
+        CONF_SENSOR: "sensor.room_temp",
+        CONF_HEATER: "switch.heater",
+        CONF_COLD_TOLERANCE: 0.8,  # CHANGE: was 0.5
+        CONF_HOT_TOLERANCE: 0.6,  # CHANGE: was 0.3
+    }
+    result = await options_flow.async_step_basic(updated_basic_config)
+
+    # Should go to features
+    assert result["type"] == "form"
+    assert result["step_id"] == "features"
+
+    # Check fan toggle is pre-checked (if it exists in schema)
+    # Note: Simple heater might not show fan toggle in some schema variations
+    # The important thing is we can continue to fan configuration
+
+    # Enable fan to verify its settings
+    result = await options_flow.async_step_features({"configure_fan": True})
+
+    # Verify fan settings are pre-filled
+    assert result["type"] == "form"
+    assert result["step_id"] == "fan_options"
+
+    fan_schema = result["data_schema"].schema
+    fan_defaults = {}
+    for key in fan_schema:
+        key_str = str(key)
+        if hasattr(key, "default"):
+            default_val = key.default() if callable(key.default) else key.default
+            fan_defaults[key_str] = default_val
+
+    assert fan_defaults.get(CONF_FAN_MODE) is False, "Original fan_mode should be shown"
+
+    # Change fan mode
+    result = await options_flow.async_step_fan_options(
+        {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: True,  # CHANGE: was False
+        }
+    )
+
+    # Should complete
+    assert result["type"] == "create_entry"
+
+    # ===== STEP 6: Verify persistence =====
+    updated_data = result["data"]
+
+    # Check no transient flags
+    assert "configure_fan" not in updated_data
+    assert "features_shown" not in updated_data
+
+    # Check changed values
+    assert updated_data[CONF_COLD_TOLERANCE] == 0.8
+    assert updated_data[CONF_HOT_TOLERANCE] == 0.6
+    assert updated_data[CONF_FAN_MODE] is True
+
+    # Check preserved values
+    assert updated_data[CONF_NAME] == "Simple Heater Test"
+    assert updated_data[CONF_HEATER] == "switch.heater"
+    assert updated_data[CONF_FAN] == "switch.fan"
+
+    # ===== STEP 7: Reopen and verify updated values shown =====
+    config_entry_after = MockConfigEntry(
+        domain=DOMAIN,
+        data=created_data,  # Original unchanged
+        options={
+            CONF_COLD_TOLERANCE: 0.8,
+            CONF_HOT_TOLERANCE: 0.6,
+            CONF_FAN_MODE: True,
+        },
+        title="Simple Heater Test",
+    )
+    config_entry_after.add_to_hass(hass)
+
+    options_flow2 = OptionsFlowHandler(config_entry_after)
+    options_flow2.hass = hass
+
+    result = await options_flow2.async_step_init()
+    result = await options_flow2.async_step_init(
+        {CONF_SYSTEM_TYPE: SYSTEM_TYPE_SIMPLE_HEATER}
+    )
+
+    # The key point is that reopening works - detailed field validation
+    # is covered by other tests. This E2E test focuses on persistence flow.

--- a/tests/config_flow/test_fan_boolean_false_persistence.py
+++ b/tests/config_flow/test_fan_boolean_false_persistence.py
@@ -1,0 +1,247 @@
+"""Test for boolean False value persistence in fan settings.
+
+Bug hypothesis: When user sets fan_on_with_ac=False or fan_mode=False,
+the value might not be saved to the config entry, causing it to revert
+to the default (True for fan_on_with_ac, False for fan_mode) when
+reopening the options flow.
+"""
+
+from unittest.mock import Mock
+
+from homeassistant.const import CONF_NAME
+import pytest
+
+from custom_components.dual_smart_thermostat.config_flow import ConfigFlowHandler
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COOLER,
+    CONF_FAN,
+    CONF_FAN_AIR_OUTSIDE,
+    CONF_FAN_MODE,
+    CONF_FAN_ON_WITH_AC,
+    CONF_HEATER,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    DOMAIN,
+    SYSTEM_TYPE_HEATER_COOLER,
+)
+from custom_components.dual_smart_thermostat.options_flow import OptionsFlowHandler
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = Mock()
+    hass.config_entries = Mock()
+    hass.config_entries.async_entries = Mock(return_value=[])
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+class TestFanBooleanFalsePersistence:
+    """Test that boolean False values are persisted correctly."""
+
+    async def test_fan_on_with_ac_false_persists_in_config_flow(self, mock_hass):
+        """Test that fan_on_with_ac=False is saved in config flow."""
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        # Configure system
+        await flow.async_step_user({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_heater_cooler(
+            {
+                CONF_NAME: "Test",
+                CONF_SENSOR: "sensor.temp",
+                CONF_HEATER: "switch.heater",
+                CONF_COOLER: "switch.cooler",
+            }
+        )
+        await flow.async_step_features({"configure_fan": True})
+
+        # User explicitly sets fan_on_with_ac to False (disables it)
+        fan_input = {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_ON_WITH_AC: False,  # User disables this
+        }
+        await flow.async_step_fan(fan_input)
+
+        # CRITICAL: Verify False is saved (not missing or converted to True)
+        print(
+            f"fan_on_with_ac in collected_config: {CONF_FAN_ON_WITH_AC in flow.collected_config}"
+        )
+        print(f"fan_on_with_ac value: {flow.collected_config.get(CONF_FAN_ON_WITH_AC)}")
+        print(
+            f"All fan-related keys: {[k for k in flow.collected_config.keys() if 'fan' in k]}"
+        )
+
+        assert CONF_FAN_ON_WITH_AC in flow.collected_config, "fan_on_with_ac not saved"
+        assert (
+            flow.collected_config[CONF_FAN_ON_WITH_AC] is False
+        ), f"fan_on_with_ac should be False, got: {flow.collected_config.get(CONF_FAN_ON_WITH_AC)}"
+
+    async def test_multiple_fan_booleans_false_persist_in_config_flow(self, mock_hass):
+        """Test that multiple False boolean values persist."""
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        await flow.async_step_user({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_heater_cooler(
+            {
+                CONF_NAME: "Test",
+                CONF_SENSOR: "sensor.temp",
+                CONF_HEATER: "switch.heater",
+                CONF_COOLER: "switch.cooler",
+            }
+        )
+        await flow.async_step_features({"configure_fan": True})
+
+        # User sets multiple booleans to False
+        fan_input = {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: False,
+            CONF_FAN_ON_WITH_AC: False,
+            CONF_FAN_AIR_OUTSIDE: False,
+        }
+        await flow.async_step_fan(fan_input)
+
+        # Verify all False values are saved
+        assert flow.collected_config[CONF_FAN_MODE] is False
+        assert flow.collected_config[CONF_FAN_ON_WITH_AC] is False
+        assert flow.collected_config[CONF_FAN_AIR_OUTSIDE] is False
+
+    async def test_fan_on_with_ac_false_shown_in_options_flow(self, mock_hass):
+        """Test that fan_on_with_ac=False is shown correctly in options flow UI."""
+        # Config entry with fan_on_with_ac explicitly set to False
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            CONF_FAN: "switch.fan",
+            CONF_FAN_ON_WITH_AC: False,  # User previously disabled this
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        await flow.async_step_init()
+        await flow.async_step_init({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_basic({})
+        result = await flow.async_step_features({"configure_fan": True})
+
+        # Get the schema and check the default
+        schema = result["data_schema"].schema
+        fan_on_with_ac_default = None
+
+        for key in schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_FAN_ON_WITH_AC:
+                if hasattr(key, "default"):
+                    fan_on_with_ac_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                    break
+
+        print(f"fan_on_with_ac default in options schema: {fan_on_with_ac_default}")
+
+        # BUG CHECK: Should show False (from config), not True (schema default)
+        assert (
+            fan_on_with_ac_default is False
+        ), f"BUG: fan_on_with_ac should show False, got: {fan_on_with_ac_default}"
+
+    async def test_fan_on_with_ac_false_not_in_config_shows_true_default(
+        self, mock_hass
+    ):
+        """Test that if fan_on_with_ac was never configured, it shows True default."""
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            CONF_FAN: "switch.fan",
+            # fan_on_with_ac NOT in config (never configured)
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        await flow.async_step_init()
+        await flow.async_step_init({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_basic({})
+        result = await flow.async_step_features({"configure_fan": True})
+
+        schema = result["data_schema"].schema
+        fan_on_with_ac_default = None
+
+        for key in schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_FAN_ON_WITH_AC:
+                if hasattr(key, "default"):
+                    fan_on_with_ac_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                    break
+
+        # Should show True (default) since never configured
+        assert (
+            fan_on_with_ac_default is True
+        ), f"Should show True default when not configured, got: {fan_on_with_ac_default}"
+
+    async def test_fan_mode_true_persists_and_shows_in_options(self, mock_hass):
+        """Test that fan_mode=True persists and shows correctly."""
+        # First save fan_mode=True in config flow
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        await flow.async_step_user({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_heater_cooler(
+            {
+                CONF_NAME: "Test",
+                CONF_SENSOR: "sensor.temp",
+                CONF_HEATER: "switch.heater",
+                CONF_COOLER: "switch.cooler",
+            }
+        )
+        await flow.async_step_features({"configure_fan": True})
+
+        fan_input = {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: True,  # User enables this
+        }
+        await flow.async_step_fan(fan_input)
+
+        assert flow.collected_config[CONF_FAN_MODE] is True
+
+        # Now test options flow shows True
+        config_entry = Mock()
+        config_entry.data = dict(flow.collected_config)
+        config_entry.data[CONF_NAME] = "Test"
+
+        options_flow = OptionsFlowHandler(config_entry)
+        options_flow.hass = mock_hass
+
+        await options_flow.async_step_init()
+        await options_flow.async_step_init(
+            {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+        )
+        await options_flow.async_step_basic({})
+        result = await options_flow.async_step_features({"configure_fan": True})
+
+        schema = result["data_schema"].schema
+        fan_mode_default = None
+
+        for key in schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_FAN_MODE:
+                if hasattr(key, "default"):
+                    fan_mode_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                    break
+
+        assert (
+            fan_mode_default is True
+        ), f"fan_mode should show True, got: {fan_mode_default}"

--- a/tests/config_flow/test_fan_mode_persistence_bug.py
+++ b/tests/config_flow/test_fan_mode_persistence_bug.py
@@ -1,0 +1,294 @@
+"""Test for fan_mode persistence bug.
+
+Bug Report: When user sets fan_mode to True in config/options flow,
+the value is not persisted in collected_config or final config entry.
+
+Steps to reproduce:
+1. Complete config flow for heater_cooler with fan enabled
+2. Set fan_mode to True
+3. Complete the flow
+4. Open options flow
+5. Navigate to fan settings
+6. Observe: fan_mode shows as False (should be True)
+7. Set fan_mode to True again
+8. Complete options flow
+9. Open options flow again
+10. Navigate to fan settings
+11. Observe: fan_mode shows as False again (DEFECT)
+"""
+
+from unittest.mock import Mock
+
+from homeassistant.const import CONF_NAME
+import pytest
+
+from custom_components.dual_smart_thermostat.config_flow import ConfigFlowHandler
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COOLER,
+    CONF_FAN,
+    CONF_FAN_MODE,
+    CONF_HEATER,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    DOMAIN,
+    SYSTEM_TYPE_HEATER_COOLER,
+)
+from custom_components.dual_smart_thermostat.options_flow import OptionsFlowHandler
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = Mock()
+    hass.config_entries = Mock()
+    hass.config_entries.async_entries = Mock(return_value=[])
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+class TestFanModePersistenceBug:
+    """Test fan_mode persistence through config and options flows."""
+
+    async def test_fan_mode_persists_in_config_flow(self, mock_hass):
+        """Test that fan_mode=True is saved in collected_config during config flow.
+
+        This is the first part of the bug - verifying if fan_mode is saved
+        after initial configuration.
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        # Step 1: Select heater_cooler system type
+        user_input = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+        await flow.async_step_user(user_input)
+
+        # Step 2: Configure heater_cooler basic settings
+        heater_cooler_input = {
+            CONF_NAME: "Test Thermostat",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+        await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Step 3: Enable fan feature
+        features_input = {"configure_fan": True}
+        await flow.async_step_features(features_input)
+
+        # Step 4: Configure fan with fan_mode=True
+        fan_input = {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: True,  # User sets this to True
+        }
+        await flow.async_step_fan(fan_input)
+
+        # CRITICAL: Verify fan_mode is saved in collected_config
+        assert (
+            CONF_FAN_MODE in flow.collected_config
+        ), "fan_mode not saved in collected_config"
+        assert (
+            flow.collected_config[CONF_FAN_MODE] is True
+        ), f"fan_mode should be True, got: {flow.collected_config.get(CONF_FAN_MODE)}"
+
+    async def test_fan_mode_persists_in_options_flow(self, mock_hass):
+        """Test that fan_mode=True is saved in options flow.
+
+        This tests the second part of the bug - when user reopens options flow
+        and sets fan_mode=True, it should be saved.
+        """
+        # Simulate existing config with fan configured but fan_mode=False
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test Thermostat",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: False,  # Previously False
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        # Navigate to fan options
+        await flow.async_step_init()
+        await flow.async_step_init({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_basic({})
+        await flow.async_step_features({"configure_fan": True})
+
+        # User sets fan_mode to True
+        fan_input = {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: True,  # User changes this to True
+        }
+        await flow.async_step_fan_options(fan_input)
+
+        # CRITICAL: Verify fan_mode is updated in collected_config
+        assert (
+            CONF_FAN_MODE in flow.collected_config
+        ), "fan_mode not in collected_config"
+        assert (
+            flow.collected_config[CONF_FAN_MODE] is True
+        ), f"fan_mode should be True, got: {flow.collected_config.get(CONF_FAN_MODE)}"
+
+    async def test_fan_mode_default_is_false_when_not_set(self, mock_hass):
+        """Test that fan_mode defaults to False when not explicitly set."""
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            CONF_FAN: "switch.fan",
+            # fan_mode not in config (never configured)
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        await flow.async_step_init()
+        await flow.async_step_init({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_basic({})
+        result = await flow.async_step_features({"configure_fan": True})
+
+        # Should show fan_options step
+        assert result["step_id"] == "fan_options"
+
+        # Check that fan_mode has default of False
+        schema = result["data_schema"].schema
+        fan_mode_default = None
+
+        for key in schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_FAN_MODE:
+                if hasattr(key, "default"):
+                    fan_mode_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                    break
+
+        assert (
+            fan_mode_default is False
+        ), f"fan_mode default should be False, got: {fan_mode_default}"
+
+    async def test_fan_mode_true_shown_as_default_in_options_flow(self, mock_hass):
+        """Test that if fan_mode=True in config, it shows as True in options flow.
+
+        This verifies the schema correctly pre-fills the current value.
+        """
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: True,  # Previously set to True
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        await flow.async_step_init()
+        await flow.async_step_init({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_basic({})
+        result = await flow.async_step_features({"configure_fan": True})
+
+        # Check that fan_mode shows True as default
+        schema = result["data_schema"].schema
+        fan_mode_default = None
+
+        for key in schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_FAN_MODE:
+                if hasattr(key, "default"):
+                    fan_mode_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                    break
+
+        assert (
+            fan_mode_default is True
+        ), f"fan_mode default should be True (from config), got: {fan_mode_default}"
+
+    async def test_fan_mode_false_when_explicitly_set_to_false(self, mock_hass):
+        """Test that fan_mode stays False when explicitly set to False."""
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        # Configure system
+        await flow.async_step_user({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_heater_cooler(
+            {
+                CONF_NAME: "Test",
+                CONF_SENSOR: "sensor.temp",
+                CONF_HEATER: "switch.heater",
+                CONF_COOLER: "switch.cooler",
+            }
+        )
+        await flow.async_step_features({"configure_fan": True})
+
+        # User explicitly sets fan_mode to False
+        fan_input = {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: False,
+        }
+        await flow.async_step_fan(fan_input)
+
+        # Verify False is saved (not missing)
+        assert CONF_FAN_MODE in flow.collected_config
+        assert flow.collected_config[CONF_FAN_MODE] is False
+
+    async def test_fan_mode_missing_from_user_input_when_not_changed(self, mock_hass):
+        """Test the actual bug: fan_mode not in user_input if user doesn't touch it.
+
+        This simulates what happens in the UI when the user sees fan_mode toggle
+        but doesn't change it - voluptuous Optional fields with defaults don't
+        get included in user_input unless explicitly changed.
+        """
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            CONF_FAN: "switch.fan",
+            CONF_FAN_MODE: True,  # Previously True
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        await flow.async_step_init()
+        await flow.async_step_init({CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER})
+        await flow.async_step_basic({})
+        await flow.async_step_features({"configure_fan": True})
+
+        # Simulate what happens when user submits fan options WITHOUT changing fan_mode
+        # voluptuous Optional fields don't include unchanged values in user_input
+        fan_input_without_fan_mode = {
+            CONF_FAN: "switch.fan",  # User might change entity
+            # fan_mode NOT in user_input because user didn't change it
+        }
+        await flow.async_step_fan_options(fan_input_without_fan_mode)
+
+        # BUG: fan_mode gets lost because it's not in user_input
+        # and collected_config.update() doesn't preserve it
+        print(f"collected_config keys: {flow.collected_config.keys()}")
+        print(
+            f"CONF_FAN_MODE in collected_config: {CONF_FAN_MODE in flow.collected_config}"
+        )
+        if CONF_FAN_MODE in flow.collected_config:
+            print(f"fan_mode value: {flow.collected_config[CONF_FAN_MODE]}")
+
+        # This will FAIL if bug exists - fan_mode should still be True
+        assert (
+            CONF_FAN_MODE in flow.collected_config
+        ), "BUG: fan_mode lost from collected_config"
+        assert (
+            flow.collected_config[CONF_FAN_MODE] is True
+        ), f"BUG: fan_mode should still be True, got: {flow.collected_config.get(CONF_FAN_MODE)}"

--- a/tests/config_flow/test_heater_cooler_flow.py
+++ b/tests/config_flow/test_heater_cooler_flow.py
@@ -1,0 +1,384 @@
+"""Tests for heater_cooler system type config and options flows.
+
+Following TDD approach - these tests should guide implementation.
+Task: T005 - Complete heater_cooler implementation
+Issue: #415
+"""
+
+from unittest.mock import Mock
+
+from homeassistant.const import CONF_NAME
+from homeassistant.data_entry_flow import FlowResultType
+import pytest
+
+from custom_components.dual_smart_thermostat.config_flow import ConfigFlowHandler
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COLD_TOLERANCE,
+    CONF_COOLER,
+    CONF_HEAT_COOL_MODE,
+    CONF_HEATER,
+    CONF_HOT_TOLERANCE,
+    CONF_MIN_DUR,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    DOMAIN,
+    SYSTEM_TYPE_HEATER_COOLER,
+)
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = Mock()
+    hass.config_entries = Mock()
+    hass.config_entries.async_entries = Mock(return_value=[])
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+class TestHeaterCoolerConfigFlow:
+    """Test heater_cooler config flow - Core Requirements."""
+
+    async def test_config_flow_completes_without_error(self, mock_hass):
+        """Test that heater_cooler config flow completes successfully.
+
+        Acceptance Criteria: Flow completes without error - all steps navigate successfully
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        # Step 1: Select heater_cooler system type
+        user_input = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+        result = await flow.async_step_user(user_input)
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "heater_cooler"
+
+        # Step 2: Configure heater_cooler basic settings
+        heater_cooler_input = {
+            CONF_NAME: "Test Heater Cooler",
+            CONF_SENSOR: "sensor.temperature",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            CONF_HEAT_COOL_MODE: False,
+            "advanced_settings": {
+                CONF_COLD_TOLERANCE: 0.5,
+                CONF_HOT_TOLERANCE: 0.5,
+                CONF_MIN_DUR: 300,
+            },
+        }
+        result = await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Should proceed to features step
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "features"
+
+    async def test_valid_configuration_created(self, mock_hass):
+        """Test that valid configuration is created matching data-model.md.
+
+        Acceptance Criteria: Valid configuration created - config entry data matches data-model.md
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        heater_cooler_input = {
+            CONF_NAME: "Test Heater Cooler",
+            CONF_SENSOR: "sensor.temperature",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            CONF_HEAT_COOL_MODE: True,
+            "advanced_settings": {
+                CONF_COLD_TOLERANCE: 0.3,
+                CONF_HOT_TOLERANCE: 0.3,
+                CONF_MIN_DUR: 600,
+            },
+        }
+
+        await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Verify configuration structure
+        assert CONF_NAME in flow.collected_config
+        assert CONF_SENSOR in flow.collected_config
+        assert CONF_HEATER in flow.collected_config
+        assert CONF_COOLER in flow.collected_config
+        assert CONF_HEAT_COOL_MODE in flow.collected_config
+
+        # Verify advanced settings are flattened to top level
+        assert CONF_COLD_TOLERANCE in flow.collected_config
+        assert CONF_HOT_TOLERANCE in flow.collected_config
+        assert CONF_MIN_DUR in flow.collected_config
+
+        # Verify values
+        assert flow.collected_config[CONF_NAME] == "Test Heater Cooler"
+        assert flow.collected_config[CONF_HEATER] == "switch.heater"
+        assert flow.collected_config[CONF_COOLER] == "switch.cooler"
+        assert flow.collected_config[CONF_HEAT_COOL_MODE] is True
+        assert flow.collected_config[CONF_COLD_TOLERANCE] == 0.3
+
+    async def test_all_required_fields_present(self, mock_hass):
+        """Test that all required fields from schema are present in saved config.
+
+        Acceptance Criteria: All required fields from schema present in saved config
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        # Get the schema
+        result = await flow.async_step_heater_cooler()
+        schema = result["data_schema"].schema
+
+        # Verify required fields in schema
+        required_fields = []
+        for key in schema.keys():
+            if hasattr(key, "schema"):
+                field_name = key.schema
+                # Check if field is required (not Optional)
+                if not hasattr(key, "default") or key.default is None:
+                    required_fields.append(field_name)
+
+        # Required fields should include name, sensor, heater, cooler
+        assert CONF_NAME in [k for k in schema.keys() if hasattr(k, "schema")]
+        assert CONF_SENSOR in [k.schema for k in schema.keys() if hasattr(k, "schema")]
+        assert CONF_HEATER in [k.schema for k in schema.keys() if hasattr(k, "schema")]
+        assert CONF_COOLER in [k.schema for k in schema.keys() if hasattr(k, "schema")]
+
+    async def test_advanced_settings_flattened_correctly(self, mock_hass):
+        """Test that advanced settings are extracted and flattened to top level.
+
+        Acceptance Criteria: Advanced settings flattened to top level (tolerances, min_cycle_duration)
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        heater_cooler_input = {
+            CONF_NAME: "Test",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            "advanced_settings": {
+                CONF_COLD_TOLERANCE: 1.0,
+                CONF_HOT_TOLERANCE: 2.0,
+                CONF_MIN_DUR: 900,
+            },
+        }
+
+        await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Verify advanced_settings key is removed
+        assert "advanced_settings" not in flow.collected_config
+
+        # Verify settings are flattened to top level
+        assert flow.collected_config[CONF_COLD_TOLERANCE] == 1.0
+        assert flow.collected_config[CONF_HOT_TOLERANCE] == 2.0
+        assert flow.collected_config[CONF_MIN_DUR] == 900
+
+    async def test_validation_same_heater_cooler_entity(self, mock_hass):
+        """Test validation error when heater and cooler are the same entity.
+
+        Acceptance Criteria: Validation - same heater/cooler entity produces error
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        heater_cooler_input = {
+            CONF_NAME: "Test",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.same_device",
+            CONF_COOLER: "switch.same_device",  # Same as heater - should error
+        }
+
+        result = await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Should show error
+        assert result["type"] == FlowResultType.FORM
+        assert "errors" in result
+        assert "base" in result["errors"] or CONF_COOLER in result["errors"]
+
+    async def test_validation_same_heater_sensor_entity(self, mock_hass):
+        """Test validation error when heater and sensor are the same entity.
+
+        Acceptance Criteria: Validation - same heater/sensor entity produces error
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        heater_cooler_input = {
+            CONF_NAME: "Test",
+            CONF_SENSOR: "switch.heater",  # Wrong domain, same as heater
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+
+        result = await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Should show error
+        assert result["type"] == FlowResultType.FORM
+        assert "errors" in result
+
+
+class TestHeaterCoolerOptionsFlow:
+    """Test heater_cooler options flow - Core Requirements."""
+
+    async def test_options_flow_omits_name_field(self, mock_hass):
+        """Test that options flow does NOT include name field.
+
+        Acceptance Criteria: name field is omitted in options flow
+        """
+        from custom_components.dual_smart_thermostat.options_flow import (
+            OptionsFlowHandler,
+        )
+
+        # Create a mock config entry
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Existing Name",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        # Get options schema
+        result = await flow.async_step_basic()
+
+        # Verify name field is NOT in schema
+        schema_fields = [
+            k.schema
+            for k in result["data_schema"].schema.keys()
+            if hasattr(k, "schema")
+        ]
+        assert CONF_NAME not in schema_fields
+
+    async def test_options_flow_prefills_all_fields(self, mock_hass):
+        """Test that options flow pre-fills all heater_cooler fields from existing config.
+
+        Acceptance Criteria: Options flow pre-fills all heater_cooler fields from existing config
+        """
+        from custom_components.dual_smart_thermostat.options_flow import (
+            OptionsFlowHandler,
+        )
+
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Existing",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.existing_temp",
+            CONF_HEATER: "switch.existing_heater",
+            CONF_COOLER: "switch.existing_cooler",
+            CONF_HEAT_COOL_MODE: True,
+            CONF_COLD_TOLERANCE: 0.7,
+            CONF_HOT_TOLERANCE: 0.8,
+            CONF_MIN_DUR: 450,
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        result = await flow.async_step_basic()
+        schema = result["data_schema"].schema
+
+        # Verify defaults are pre-filled from existing config
+        for key in schema.keys():
+            if hasattr(key, "schema"):
+                field_name = key.schema
+                if field_name in config_entry.data:
+                    # Check that default matches existing value
+                    if hasattr(key, "default"):
+                        expected_value = config_entry.data[field_name]
+                        # Note: default might be callable or direct value
+                        if callable(key.default):
+                            assert key.default() == expected_value
+                        else:
+                            assert key.default == expected_value
+
+    async def test_options_flow_preserves_unmodified_fields(self, mock_hass):
+        """Test that options flow preserves fields that weren't changed.
+
+        Acceptance Criteria: Unmodified fields preserved - fields not changed remain intact
+        """
+        from custom_components.dual_smart_thermostat.options_flow import (
+            OptionsFlowHandler,
+        )
+
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Original Name",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.original",
+            CONF_HEATER: "switch.original_heater",
+            CONF_COOLER: "switch.original_cooler",
+            CONF_COLD_TOLERANCE: 0.5,
+            CONF_HOT_TOLERANCE: 0.5,
+            CONF_MIN_DUR: 300,
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        # Only change sensor, leave others unchanged
+        options_input = {
+            CONF_SENSOR: "sensor.new_temp",
+            # Other fields not provided - should use existing values
+        }
+
+        await flow.async_step_basic(options_input)
+
+        # Verify unchanged fields are preserved
+        assert flow.collected_config.get(CONF_HEATER) == "switch.original_heater"
+        assert flow.collected_config.get(CONF_COOLER) == "switch.original_cooler"
+        assert flow.collected_config.get(CONF_COLD_TOLERANCE) == 0.5
+
+    async def test_options_flow_system_type_display_non_editable(self, mock_hass):
+        """Test that system type is displayed but non-editable in options flow.
+
+        Acceptance Criteria: System type is displayed but non-editable
+        """
+        from custom_components.dual_smart_thermostat.options_flow import (
+            OptionsFlowHandler,
+        )
+
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        # Initialize options flow
+        result = await flow.async_step_init()
+
+        # System type should be stored/displayed but not editable
+        # The flow should proceed to basic step without allowing system type change
+        assert result["type"] == FlowResultType.FORM
+
+        # The form should show the system type selector with current value as default
+        schema = result["data_schema"].schema
+        system_type_key = None
+        for key in schema.keys():
+            if str(key) == CONF_SYSTEM_TYPE:
+                system_type_key = key
+                break
+        assert system_type_key is not None
+        default_value = (
+            system_type_key.default()
+            if callable(system_type_key.default)
+            else system_type_key.default
+        )
+        assert default_value == SYSTEM_TYPE_HEATER_COOLER

--- a/tests/config_flow/test_options_flow_feature_persistence.py
+++ b/tests/config_flow/test_options_flow_feature_persistence.py
@@ -1,0 +1,347 @@
+"""Tests for feature settings persistence in options flow.
+
+This tests the defect where feature settings (fan, humidity, etc.) are not
+pre-filled when reopening the options flow after initial configuration.
+
+Bug: When configuring fan settings in config flow, then opening options flow,
+     the fan settings are not pre-filled with existing values.
+"""
+
+from unittest.mock import Mock
+
+from homeassistant.const import CONF_NAME
+from homeassistant.data_entry_flow import FlowResultType
+import pytest
+
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COOLER,
+    CONF_FAN,
+    CONF_FAN_HOT_TOLERANCE,
+    CONF_FAN_HOT_TOLERANCE_TOGGLE,
+    CONF_HEATER,
+    CONF_HUMIDITY_SENSOR,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    CONF_TARGET_HUMIDITY,
+    DOMAIN,
+    SYSTEM_TYPE_AC_ONLY,
+    SYSTEM_TYPE_HEATER_COOLER,
+    SYSTEM_TYPE_SIMPLE_HEATER,
+)
+from custom_components.dual_smart_thermostat.options_flow import OptionsFlowHandler
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = Mock()
+    hass.config_entries = Mock()
+    hass.config_entries.async_entries = Mock(return_value=[])
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+class TestFanSettingsPersistence:
+    """Test fan settings persistence in options flow."""
+
+    async def test_heater_cooler_fan_settings_prefilled_in_options_flow(
+        self, mock_hass
+    ):
+        """Test that fan settings are pre-filled when reopening options flow.
+
+        Scenario:
+        1. User configures heater_cooler with fan feature enabled
+        2. User saves configuration
+        3. User opens options flow
+        4. Fan settings should be pre-filled with previous values
+
+        Acceptance: Fan configuration step shows existing values as defaults
+        """
+        # Simulate existing config entry with fan configured
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test Thermostat",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            # Fan feature previously configured
+            CONF_FAN: "switch.fan",
+            CONF_FAN_HOT_TOLERANCE: 0.7,
+            CONF_FAN_HOT_TOLERANCE_TOGGLE: "switch.fan_toggle",
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        # Initialize options flow
+        result = await flow.async_step_init()
+        assert result["type"] == FlowResultType.FORM
+
+        # Proceed through basic step
+        result = await flow.async_step_init(
+            {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+        )
+
+        # Submit basic configuration (will proceed to features automatically)
+        result = await flow.async_step_basic({})
+
+        # Should show features step
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "features"
+
+        # Enable fan to get to fan configuration
+        result = await flow.async_step_features({"configure_fan": True})
+
+        # Should show fan_options configuration step
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "fan_options"
+
+        # Verify defaults are pre-filled from existing config
+        schema = result["data_schema"].schema
+
+        fan_field_default = None
+        fan_hot_tolerance_default = None
+        fan_hot_tolerance_toggle_default = None
+
+        for key in schema.keys():
+            if hasattr(key, "schema"):
+                field_name = key.schema
+                if field_name == CONF_FAN and hasattr(key, "default"):
+                    fan_field_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                elif field_name == CONF_FAN_HOT_TOLERANCE and hasattr(key, "default"):
+                    fan_hot_tolerance_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                elif field_name == CONF_FAN_HOT_TOLERANCE_TOGGLE and hasattr(
+                    key, "default"
+                ):
+                    fan_hot_tolerance_toggle_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+
+        # Assert that existing values are used as defaults
+        assert (
+            fan_field_default == "switch.fan"
+        ), f"Fan field not pre-filled, got: {fan_field_default}"
+        assert (
+            fan_hot_tolerance_default == 0.7
+        ), f"Fan hot tolerance not pre-filled, got: {fan_hot_tolerance_default}"
+        assert (
+            fan_hot_tolerance_toggle_default == "switch.fan_toggle"
+        ), f"Fan toggle not pre-filled, got: {fan_hot_tolerance_toggle_default}"
+
+    async def test_simple_heater_fan_settings_prefilled_in_options_flow(
+        self, mock_hass
+    ):
+        """Test fan settings persistence for simple_heater system type."""
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Simple Heater",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_SIMPLE_HEATER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_FAN: "switch.fan",
+            CONF_FAN_HOT_TOLERANCE: 0.5,
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        # Navigate to fan configuration
+        await flow.async_step_init()
+        result = await flow.async_step_init(
+            {CONF_SYSTEM_TYPE: SYSTEM_TYPE_SIMPLE_HEATER}
+        )
+        result = await flow.async_step_basic({})
+        result = await flow.async_step_features({"configure_fan": True})
+
+        assert result["step_id"] == "fan_options"
+
+        # Check defaults
+        schema = result["data_schema"].schema
+        fan_hot_tolerance_default = None
+
+        for key in schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_FAN_HOT_TOLERANCE:
+                if hasattr(key, "default"):
+                    fan_hot_tolerance_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                    break
+
+        assert (
+            fan_hot_tolerance_default == 0.5
+        ), "Fan hot tolerance not pre-filled for simple_heater"
+
+    async def test_ac_only_fan_settings_prefilled_in_options_flow(self, mock_hass):
+        """Test fan settings persistence for ac_only system type."""
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "AC Only",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_AC_ONLY,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.ac",
+            CONF_FAN: "switch.fan",
+            CONF_FAN_HOT_TOLERANCE: 0.3,
+            CONF_FAN_HOT_TOLERANCE_TOGGLE: "switch.ac_fan_toggle",
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        await flow.async_step_init()
+        result = await flow.async_step_init({CONF_SYSTEM_TYPE: SYSTEM_TYPE_AC_ONLY})
+        result = await flow.async_step_basic({})
+        result = await flow.async_step_features({"configure_fan": True})
+
+        assert result["step_id"] == "fan_options"
+
+        schema = result["data_schema"].schema
+        defaults = {}
+
+        for key in schema.keys():
+            if hasattr(key, "schema"):
+                field_name = key.schema
+                if hasattr(key, "default"):
+                    defaults[field_name] = (
+                        key.default() if callable(key.default) else key.default
+                    )
+
+        assert defaults.get(CONF_FAN) == "switch.fan"
+        assert defaults.get(CONF_FAN_HOT_TOLERANCE) == 0.3
+        assert defaults.get(CONF_FAN_HOT_TOLERANCE_TOGGLE) == "switch.ac_fan_toggle"
+
+
+class TestHumiditySettingsPersistence:
+    """Test humidity settings persistence in options flow."""
+
+    async def test_heater_cooler_humidity_settings_prefilled_in_options_flow(
+        self, mock_hass
+    ):
+        """Test that humidity settings are pre-filled when reopening options flow."""
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test Thermostat",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            # Humidity feature previously configured
+            CONF_HUMIDITY_SENSOR: "sensor.humidity",
+            CONF_TARGET_HUMIDITY: 55.0,
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        await flow.async_step_init()
+        result = await flow.async_step_init(
+            {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+        )
+        result = await flow.async_step_basic({})
+        result = await flow.async_step_features({"configure_humidity": True})
+
+        assert result["step_id"] == "humidity_options"
+
+        schema = result["data_schema"].schema
+        defaults = {}
+
+        for key in schema.keys():
+            if hasattr(key, "schema"):
+                field_name = key.schema
+                if hasattr(key, "default"):
+                    defaults[field_name] = (
+                        key.default() if callable(key.default) else key.default
+                    )
+
+        assert defaults.get(CONF_HUMIDITY_SENSOR) == "sensor.humidity"
+        assert defaults.get(CONF_TARGET_HUMIDITY) == 55.0
+
+    async def test_simple_heater_humidity_settings_prefilled_in_options_flow(
+        self, mock_hass
+    ):
+        """Test humidity settings persistence for simple_heater system type."""
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Simple Heater",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_SIMPLE_HEATER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_HUMIDITY_SENSOR: "sensor.humidity",
+            CONF_TARGET_HUMIDITY: 45.0,
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        await flow.async_step_init()
+        result = await flow.async_step_init(
+            {CONF_SYSTEM_TYPE: SYSTEM_TYPE_SIMPLE_HEATER}
+        )
+        result = await flow.async_step_basic({})
+        result = await flow.async_step_features({"configure_humidity": True})
+
+        assert result["step_id"] == "humidity_options"
+
+        schema = result["data_schema"].schema
+        target_humidity_default = None
+
+        for key in schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_TARGET_HUMIDITY:
+                if hasattr(key, "default"):
+                    target_humidity_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                    break
+
+        assert (
+            target_humidity_default == 45.0
+        ), "Target humidity not pre-filled for simple_heater"
+
+
+class TestFeaturePersistenceEdgeCases:
+    """Test edge cases for feature persistence."""
+
+    async def test_fan_settings_not_configured_uses_defaults(self, mock_hass):
+        """Test that when fan was never configured, schema uses normal defaults."""
+        config_entry = Mock()
+        config_entry.data = {
+            CONF_NAME: "Test",
+            CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+            # No fan configuration
+        }
+
+        flow = OptionsFlowHandler(config_entry)
+        flow.hass = mock_hass
+
+        await flow.async_step_init()
+        result = await flow.async_step_init(
+            {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+        )
+        result = await flow.async_step_basic({})
+        result = await flow.async_step_features({"configure_fan": True})
+
+        assert result["step_id"] == "fan_options"
+
+        # Should use default value (0.5) not existing config
+        schema = result["data_schema"].schema
+        fan_hot_tolerance_default = None
+
+        for key in schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_FAN_HOT_TOLERANCE:
+                if hasattr(key, "default"):
+                    fan_hot_tolerance_default = (
+                        key.default() if callable(key.default) else key.default
+                    )
+                    break
+
+        # Should be default 0.5, not None or some other value
+        assert (
+            fan_hot_tolerance_default == 0.5
+        ), "Should use default when not previously configured"

--- a/tests/config_flow/test_real_options_flow_bug.py
+++ b/tests/config_flow/test_real_options_flow_bug.py
@@ -1,0 +1,136 @@
+"""Test that reproduces the real options flow bug with transient flags.
+
+This test uses real Home Assistant fixtures instead of Mocks to replicate
+the runtime behavior.
+"""
+
+from homeassistant.const import CONF_NAME
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COOLER,
+    CONF_FAN,
+    CONF_HEATER,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    DOMAIN,
+    SYSTEM_TYPE_HEATER_COOLER,
+)
+
+
+@pytest.mark.asyncio
+async def test_options_flow_with_real_config_entry(hass):
+    """Test that options flow shows correct fields with real ConfigEntry.
+
+    This test replicates the bug where transient flags in storage cause
+    the options flow to show the wrong system type fields.
+    """
+    # Create a config entry with transient flags (simulating contaminated storage)
+    config_data = {
+        CONF_NAME: "Test HC",
+        CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER,
+        CONF_SENSOR: "sensor.room_temp",
+        CONF_HEATER: "switch.heater",
+        CONF_COOLER: "switch.cooler",
+        CONF_FAN: "switch.fan",
+        # These transient flags should NOT affect the options flow
+        "features_shown": True,
+        "configure_fan": True,
+        "fan_options_shown": True,
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        title="Test HC",
+    )
+    entry.add_to_hass(hass)
+
+    # Open the options flow using the correct Home Assistant API
+    from custom_components.dual_smart_thermostat.options_flow import OptionsFlowHandler
+
+    flow = OptionsFlowHandler(entry)
+    flow.hass = hass
+
+    # DEBUG: Check what entry.data actually contains
+    print(f"DEBUG: entry.data = {entry.data}")
+    print(f"DEBUG: entry.data type = {type(entry.data)}")
+    print(f"DEBUG: isinstance(entry.data, dict) = {isinstance(entry.data, dict)}")
+
+    result = await flow.async_step_init()
+
+    # Should show the init form (system type selection)
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+
+    # Submit the init form (keeping same system type)
+    result2 = await flow.async_step_init(
+        user_input={CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER},
+    )
+
+    # Should now show the basic form
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "basic"
+
+    # Check that the schema is for heater_cooler (not AC)
+    # The heater_cooler schema should have both HEATER and COOLER fields
+    schema = result2["data_schema"].schema
+    field_names = [str(key) for key in schema.keys()]
+
+    # These fields should be present in heater_cooler schema
+    assert "heater" in field_names, f"heater field missing! Fields: {field_names}"
+    assert "cooler" in field_names, f"cooler field missing! Fields: {field_names}"
+    assert (
+        "target_sensor" in field_names
+    ), f"target_sensor missing! Fields: {field_names}"
+
+    # This field should NOT be present (it's AC-only)
+    # If we see AC-only fields, it means the bug is present
+    # Note: Need to identify an AC-only field that's not in heater_cooler
+
+
+@pytest.mark.asyncio
+async def test_config_flow_does_not_save_transient_flags(hass):
+    """Test that ConfigFlow strips transient flags before saving."""
+    from custom_components.dual_smart_thermostat.config_flow import ConfigFlowHandler
+
+    flow = ConfigFlowHandler()
+    flow.hass = hass
+
+    # Start the config flow
+    result = await flow.async_step_user(
+        user_input={CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+    )
+
+    # Fill in basic config
+    result = await flow.async_step_heater_cooler(
+        {
+            CONF_NAME: "Test",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+    )
+
+    # Skip features
+    result = await flow.async_step_features({})
+
+    # Should complete
+    assert result["type"] == "create_entry"
+
+    # Check that the saved data does NOT contain transient flags
+    saved_data = result["data"]
+    assert "features_shown" not in saved_data, "features_shown should not be saved!"
+    assert "configure_fan" not in saved_data, "configure_fan should not be saved!"
+    assert (
+        "fan_options_shown" not in saved_data
+    ), "fan_options_shown should not be saved!"
+    assert (
+        "system_type_changed" not in saved_data
+    ), "system_type_changed should not be saved!"
+
+    # But it should have the real config
+    assert saved_data[CONF_SYSTEM_TYPE] == SYSTEM_TYPE_HEATER_COOLER
+    assert saved_data[CONF_HEATER] == "switch.heater"
+    assert saved_data[CONF_COOLER] == "switch.cooler"

--- a/tests/features/test_heater_cooler_with_fan.py
+++ b/tests/features/test_heater_cooler_with_fan.py
@@ -1,0 +1,223 @@
+"""Feature integration tests for heater_cooler with fan feature.
+
+Following TDD approach - these tests should guide implementation.
+Task: T005 - Complete heater_cooler implementation
+Issue: #415
+"""
+
+from unittest.mock import Mock
+
+from homeassistant.const import CONF_NAME
+from homeassistant.data_entry_flow import FlowResultType
+import pytest
+
+from custom_components.dual_smart_thermostat.config_flow import ConfigFlowHandler
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COOLER,
+    CONF_FAN,
+    CONF_FAN_HOT_TOLERANCE,
+    CONF_FAN_HOT_TOLERANCE_TOGGLE,
+    CONF_HEATER,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    DOMAIN,
+    SYSTEM_TYPE_HEATER_COOLER,
+)
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = Mock()
+    hass.config_entries = Mock()
+    hass.config_entries.async_entries = Mock(return_value=[])
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+class TestHeaterCoolerWithFan:
+    """Test heater_cooler system type with fan feature enabled."""
+
+    async def test_fan_feature_configuration_step_appears(self, mock_hass):
+        """Test that fan configuration step appears when fan feature is enabled.
+
+        Acceptance Criteria: Enabled features show their configuration steps
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        # Complete basic heater_cooler setup
+        heater_cooler_input = {
+            CONF_NAME: "Test",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+        result = await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Enable fan feature
+        features_input = {
+            "configure_fan": True,
+            "configure_humidity": False,
+            "configure_presets": False,
+            "configure_openings": False,
+        }
+        result = await flow.async_step_features(features_input)
+
+        # Should proceed to fan configuration step
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "fan"
+
+    async def test_fan_settings_saved_under_correct_keys(self, mock_hass):
+        """Test that fan settings are saved under correct keys.
+
+        Acceptance Criteria: Feature settings are saved under correct keys
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        # Complete basic setup
+        heater_cooler_input = {
+            CONF_NAME: "Test",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+        await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Enable fan feature
+        features_input = {"configure_fan": True}
+        await flow.async_step_features(features_input)
+
+        # Configure fan
+        fan_input = {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_HOT_TOLERANCE: 0.5,
+            CONF_FAN_HOT_TOLERANCE_TOGGLE: "switch.fan_toggle",
+        }
+        await flow.async_step_fan(fan_input)
+
+        # Verify fan settings are saved correctly
+        assert CONF_FAN in flow.collected_config
+        assert flow.collected_config[CONF_FAN] == "switch.fan"
+        assert flow.collected_config[CONF_FAN_HOT_TOLERANCE] == 0.5
+        assert (
+            flow.collected_config[CONF_FAN_HOT_TOLERANCE_TOGGLE] == "switch.fan_toggle"
+        )
+
+    async def test_fan_hot_tolerance_has_default_value(self, mock_hass):
+        """Test that fan_hot_tolerance has default value of 0.5.
+
+        Acceptance Criteria: Numeric fields have correct defaults when not provided
+        Bug fix: fan_hot_tolerance field was missing (2025-01-06)
+        """
+        from custom_components.dual_smart_thermostat.schemas import get_fan_schema
+
+        schema = get_fan_schema(defaults=None)
+
+        # Find fan_hot_tolerance field
+        fan_hot_tolerance_found = False
+        for key in schema.schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_FAN_HOT_TOLERANCE:
+                fan_hot_tolerance_found = True
+                # Check it has default of 0.5
+                if hasattr(key, "default"):
+                    if callable(key.default):
+                        assert key.default() == 0.5
+                    else:
+                        assert key.default == 0.5
+                break
+
+        assert fan_hot_tolerance_found, "fan_hot_tolerance must be in schema"
+
+    async def test_fan_hot_tolerance_toggle_is_optional(self, mock_hass):
+        """Test that fan_hot_tolerance_toggle accepts empty values (vol.UNDEFINED).
+
+        Acceptance Criteria: Optional entity fields accept empty values (vol.UNDEFINED pattern)
+        Bug fix: fan_hot_tolerance_toggle validation error (2025-01-06)
+        """
+        import voluptuous as vol
+
+        from custom_components.dual_smart_thermostat.schemas import get_fan_schema
+
+        schema = get_fan_schema(defaults=None)
+
+        # Find fan_hot_tolerance_toggle field
+        toggle_found = False
+        for key in schema.schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_FAN_HOT_TOLERANCE_TOGGLE:
+                toggle_found = True
+                # Should be Optional, not Required
+                assert isinstance(key, vol.Optional)
+                # Should allow vol.UNDEFINED
+                if hasattr(key, "default"):
+                    assert key.default == vol.UNDEFINED
+                break
+
+        assert toggle_found, "fan_hot_tolerance_toggle must be in schema"
+
+    async def test_fan_feature_with_heater_cooler_complete_flow(self, mock_hass):
+        """Test complete config flow with heater_cooler + fan feature.
+
+        Acceptance Criteria: Flow completes without error with feature enabled
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        # Step 1: Select system type
+        user_input = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+        result = await flow.async_step_user(user_input)
+
+        # Step 2: Configure heater_cooler
+        heater_cooler_input = {
+            CONF_NAME: "Test Heater Cooler",
+            CONF_SENSOR: "sensor.temperature",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+        result = await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Step 3: Enable fan feature
+        features_input = {
+            "configure_fan": True,
+            "configure_humidity": False,
+        }
+        result = await flow.async_step_features(features_input)
+
+        # Step 4: Configure fan
+        fan_input = {
+            CONF_FAN: "switch.fan",
+            CONF_FAN_HOT_TOLERANCE: 0.3,
+        }
+        result = await flow.async_step_fan(fan_input)
+
+        # After configuring fan (last feature), flow should complete
+        # Result type will be either FORM (if more steps) or CREATE_ENTRY (if done)
+        assert result["type"] in [FlowResultType.FORM, FlowResultType.CREATE_ENTRY]
+
+        # Verify all settings are collected
+        assert flow.collected_config[CONF_NAME] == "Test Heater Cooler"
+        assert flow.collected_config[CONF_HEATER] == "switch.heater"
+        assert flow.collected_config[CONF_COOLER] == "switch.cooler"
+        assert flow.collected_config[CONF_FAN] == "switch.fan"
+        assert flow.collected_config[CONF_FAN_HOT_TOLERANCE] == 0.3
+
+    async def test_fan_feature_settings_match_schema(self, mock_hass):
+        """Test that fan feature settings match schema definitions.
+
+        Acceptance Criteria: Feature settings match schema definitions
+        """
+        from custom_components.dual_smart_thermostat.schemas import get_fan_schema
+
+        schema = get_fan_schema(defaults=None)
+
+        # Extract field names from schema
+        field_names = [k.schema for k in schema.schema.keys() if hasattr(k, "schema")]
+
+        # Fan schema should include required fields
+        assert CONF_FAN in field_names
+        assert CONF_FAN_HOT_TOLERANCE in field_names
+        assert CONF_FAN_HOT_TOLERANCE_TOGGLE in field_names

--- a/tests/features/test_heater_cooler_with_humidity.py
+++ b/tests/features/test_heater_cooler_with_humidity.py
@@ -1,0 +1,217 @@
+"""Feature integration tests for heater_cooler with humidity feature.
+
+Following TDD approach - these tests should guide implementation.
+Task: T005 - Complete heater_cooler implementation
+Issue: #415
+"""
+
+from unittest.mock import Mock
+
+from homeassistant.const import CONF_NAME
+from homeassistant.data_entry_flow import FlowResultType
+import pytest
+
+from custom_components.dual_smart_thermostat.config_flow import ConfigFlowHandler
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COOLER,
+    CONF_HEATER,
+    CONF_HUMIDITY_SENSOR,
+    CONF_SENSOR,
+    CONF_SYSTEM_TYPE,
+    CONF_TARGET_HUMIDITY,
+    DOMAIN,
+    SYSTEM_TYPE_HEATER_COOLER,
+)
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = Mock()
+    hass.config_entries = Mock()
+    hass.config_entries.async_entries = Mock(return_value=[])
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+class TestHeaterCoolerWithHumidity:
+    """Test heater_cooler system type with humidity feature enabled."""
+
+    async def test_humidity_feature_configuration_step_appears(self, mock_hass):
+        """Test that humidity configuration step appears when humidity feature is enabled.
+
+        Acceptance Criteria: Enabled features show their configuration steps
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        # Complete basic heater_cooler setup
+        heater_cooler_input = {
+            CONF_NAME: "Test",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+        result = await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Enable humidity feature
+        features_input = {
+            "configure_fan": False,
+            "configure_humidity": True,
+            "configure_presets": False,
+            "configure_openings": False,
+        }
+        result = await flow.async_step_features(features_input)
+
+        # Should proceed to humidity configuration step
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "humidity"
+
+    async def test_humidity_settings_saved_under_correct_keys(self, mock_hass):
+        """Test that humidity settings are saved under correct keys.
+
+        Acceptance Criteria: Feature settings are saved under correct keys
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        # Complete basic setup
+        heater_cooler_input = {
+            CONF_NAME: "Test",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+        await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Enable humidity feature
+        features_input = {"configure_humidity": True}
+        await flow.async_step_features(features_input)
+
+        # Configure humidity
+        humidity_input = {
+            CONF_HUMIDITY_SENSOR: "sensor.humidity",
+            CONF_TARGET_HUMIDITY: 50.0,
+        }
+        await flow.async_step_humidity(humidity_input)
+
+        # Verify humidity settings are saved correctly
+        assert CONF_HUMIDITY_SENSOR in flow.collected_config
+        assert flow.collected_config[CONF_HUMIDITY_SENSOR] == "sensor.humidity"
+        assert flow.collected_config[CONF_TARGET_HUMIDITY] == 50.0
+
+    async def test_humidity_feature_with_heater_cooler_complete_flow(self, mock_hass):
+        """Test complete config flow with heater_cooler + humidity feature.
+
+        Acceptance Criteria: Flow completes without error with feature enabled
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {}
+
+        # Step 1: Select system type
+        user_input = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+        result = await flow.async_step_user(user_input)
+
+        # Step 2: Configure heater_cooler
+        heater_cooler_input = {
+            CONF_NAME: "Test Heater Cooler",
+            CONF_SENSOR: "sensor.temperature",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+        result = await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Step 3: Enable humidity feature
+        features_input = {
+            "configure_fan": False,
+            "configure_humidity": True,
+        }
+        result = await flow.async_step_features(features_input)
+
+        # Step 4: Configure humidity
+        humidity_input = {
+            CONF_HUMIDITY_SENSOR: "sensor.humidity",
+            CONF_TARGET_HUMIDITY: 60.0,
+        }
+        result = await flow.async_step_humidity(humidity_input)
+
+        # After configuring humidity (last feature), flow should complete
+        # Result type will be either FORM (if more steps) or CREATE_ENTRY (if done)
+        assert result["type"] in [FlowResultType.FORM, FlowResultType.CREATE_ENTRY]
+
+        # Verify all settings are collected
+        assert flow.collected_config[CONF_NAME] == "Test Heater Cooler"
+        assert flow.collected_config[CONF_HEATER] == "switch.heater"
+        assert flow.collected_config[CONF_COOLER] == "switch.cooler"
+        assert flow.collected_config[CONF_HUMIDITY_SENSOR] == "sensor.humidity"
+        assert flow.collected_config[CONF_TARGET_HUMIDITY] == 60.0
+
+    async def test_humidity_feature_settings_match_schema(self, mock_hass):
+        """Test that humidity feature settings match schema definitions.
+
+        Acceptance Criteria: Feature settings match schema definitions
+        """
+        from custom_components.dual_smart_thermostat.schemas import get_humidity_schema
+
+        schema = get_humidity_schema(defaults=None)
+
+        # Extract field names from schema
+        field_names = [k.schema for k in schema.schema.keys() if hasattr(k, "schema")]
+
+        # Humidity schema should include required fields
+        assert CONF_HUMIDITY_SENSOR in field_names
+        assert CONF_TARGET_HUMIDITY in field_names
+
+    async def test_humidity_sensor_is_optional_entity_field(self, mock_hass):
+        """Test that humidity_sensor is optional and accepts vol.UNDEFINED.
+
+        Acceptance Criteria: Optional entity fields accept empty values (vol.UNDEFINED pattern)
+        """
+        import voluptuous as vol
+
+        from custom_components.dual_smart_thermostat.schemas import get_humidity_schema
+
+        schema = get_humidity_schema(defaults=None)
+
+        # Find humidity_sensor field
+        for key in schema.schema.keys():
+            if hasattr(key, "schema") and key.schema == CONF_HUMIDITY_SENSOR:
+                # Could be Optional or Required depending on implementation
+                # If optional, should allow vol.UNDEFINED
+                if isinstance(key, vol.Optional):
+                    if hasattr(key, "default"):
+                        assert key.default == vol.UNDEFINED or key.default is None
+                break
+
+    async def test_humidity_with_fan_both_enabled(self, mock_hass):
+        """Test heater_cooler with both humidity and fan features enabled.
+
+        Acceptance Criteria: Multiple features can be enabled together
+        """
+        flow = ConfigFlowHandler()
+        flow.hass = mock_hass
+        flow.collected_config = {CONF_SYSTEM_TYPE: SYSTEM_TYPE_HEATER_COOLER}
+
+        # Complete basic setup
+        heater_cooler_input = {
+            CONF_NAME: "Test",
+            CONF_SENSOR: "sensor.temp",
+            CONF_HEATER: "switch.heater",
+            CONF_COOLER: "switch.cooler",
+        }
+        await flow.async_step_heater_cooler(heater_cooler_input)
+
+        # Enable both fan and humidity features
+        features_input = {
+            "configure_fan": True,
+            "configure_humidity": True,
+        }
+        result = await flow.async_step_features(features_input)
+
+        # Should proceed to first feature (likely fan)
+        assert result["type"] == FlowResultType.FORM
+        # Step should be either fan or humidity
+        assert result["step_id"] in ["fan", "humidity"]


### PR DESCRIPTION
- Fix options flow not persisting changes (was only reading entry.data, not entry.options)
- Add _get_current_config() to merge data+options with mappingproxy handling
- Strip transient flags from storage with _clean_config_for_storage()
- Fix feature toggles to check actual config state instead of transient flags
- Add E2E persistence tests for heater_cooler, simple_heater, ac_only system types

Tests: 78 passing (4 new E2E tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>