### PR TITLE
fix: convert time-based config values from seconds to timedelta

### DIFF
--- a/tests/edge_cases/test_issue_484_keep_alive_timedelta.py
+++ b/tests/edge_cases/test_issue_484_keep_alive_timedelta.py
@@ -1,0 +1,223 @@
+"""Test for issue #484 - keep_alive stored as float instead of timedelta.
+
+Issue: When keep_alive is configured via config flow, it's stored as a numeric
+value (seconds) but climate.py expects a timedelta object. This causes:
+AttributeError: 'float' object has no attribute 'total_seconds'
+
+Root cause: Config flow stores time values as int/float (seconds) from NumberSelector,
+but async_track_time_interval() expects timedelta objects.
+
+Fix: _normalize_config_numeric_values() converts time-based config values
+(keep_alive, min_cycle_duration, stale_duration) from seconds to timedelta.
+"""
+
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COLD_TOLERANCE,
+    CONF_HEATER,
+    CONF_HOT_TOLERANCE,
+    CONF_KEEP_ALIVE,
+    CONF_MIN_DUR,
+    CONF_SENSOR,
+    CONF_STALE_DURATION,
+    DOMAIN,
+)
+from tests import common, setup_sensor, setup_switch
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_float_converted_to_timedelta(hass: HomeAssistant):
+    """Test that keep_alive stored as float is converted to timedelta during setup.
+
+    This reproduces issue #484 where keep_alive from config flow is stored as
+    float (300.0) but code expects timedelta(seconds=300).
+
+    Without the fix, this test would fail with:
+    AttributeError: 'float' object has no attribute 'total_seconds'
+    """
+    # Create necessary test entities
+    setup_sensor(hass, 22.0)
+    setup_switch(hass, False, common.ENT_HEATER)
+
+    # Simulate config from config flow with keep_alive as float (seconds)
+    # This mimics what the config flow UI stores
+    config_data = {
+        "name": "test",
+        CONF_HEATER: common.ENT_HEATER,
+        CONF_SENSOR: common.ENT_SENSOR,
+        CONF_COLD_TOLERANCE: 0.5,
+        CONF_HOT_TOLERANCE: 0.5,
+        CONF_KEEP_ALIVE: 300.0,  # Float from config flow, not timedelta!
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        title="test",
+    )
+    config_entry.add_to_hass(hass)
+
+    # This should NOT raise AttributeError
+    # The fix in _normalize_config_numeric_values() converts float to timedelta
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify entity was created successfully
+    state = hass.states.get(common.ENTITY)
+    assert state is not None
+    assert state.state == "off"  # Initial state
+
+
+@pytest.mark.asyncio
+async def test_min_cycle_duration_int_converted_to_timedelta(hass: HomeAssistant):
+    """Test that min_cycle_duration stored as int is converted to timedelta during setup.
+
+    min_cycle_duration from config flow is stored as int (seconds) but code may
+    expect timedelta in some places.
+    """
+    setup_sensor(hass, 22.0)
+    setup_switch(hass, False, common.ENT_HEATER)
+
+    # Simulate config from config flow with min_cycle_duration as int
+    config_data = {
+        "name": "test",
+        CONF_HEATER: common.ENT_HEATER,
+        CONF_SENSOR: common.ENT_SENSOR,
+        CONF_COLD_TOLERANCE: 0.5,
+        CONF_HOT_TOLERANCE: 0.5,
+        CONF_MIN_DUR: 180,  # Int from config flow
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        title="test",
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify entity was created successfully
+    state = hass.states.get(common.ENTITY)
+    assert state is not None
+    assert state.state == "off"
+
+
+@pytest.mark.asyncio
+async def test_stale_duration_float_converted_to_timedelta(hass: HomeAssistant):
+    """Test that stale_duration stored as float is converted to timedelta during setup.
+
+    stale_duration from config flow is stored as float (seconds) but code expects
+    timedelta for sensor staleness detection.
+    """
+    setup_sensor(hass, 22.0)
+    setup_switch(hass, False, common.ENT_HEATER)
+
+    # Simulate config from config flow with stale_duration as float
+    config_data = {
+        "name": "test",
+        CONF_HEATER: common.ENT_HEATER,
+        CONF_SENSOR: common.ENT_SENSOR,
+        CONF_COLD_TOLERANCE: 0.5,
+        CONF_HOT_TOLERANCE: 0.5,
+        CONF_STALE_DURATION: 600.0,  # Float from config flow
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        title="test",
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify entity was created successfully
+    state = hass.states.get(common.ENTITY)
+    assert state is not None
+    assert state.state == "off"
+
+
+@pytest.mark.asyncio
+async def test_timedelta_values_preserved(hass: HomeAssistant):
+    """Test that timedelta values are preserved when already in correct format.
+
+    When config comes from YAML (not config flow), values may already be
+    timedelta objects. These should be preserved as-is.
+    """
+    setup_sensor(hass, 22.0)
+    setup_switch(hass, False, common.ENT_HEATER)
+
+    # Simulate config from YAML with timedelta objects
+    config_data = {
+        "name": "test",
+        CONF_HEATER: common.ENT_HEATER,
+        CONF_SENSOR: common.ENT_SENSOR,
+        CONF_COLD_TOLERANCE: 0.5,
+        CONF_HOT_TOLERANCE: 0.5,
+        CONF_KEEP_ALIVE: timedelta(seconds=300),  # Already timedelta
+        CONF_STALE_DURATION: timedelta(seconds=600),  # Already timedelta
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        title="test",
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify entity was created successfully
+    state = hass.states.get(common.ENTITY)
+    assert state is not None
+    assert state.state == "off"
+
+
+@pytest.mark.asyncio
+async def test_mixed_numeric_and_time_normalization(hass: HomeAssistant):
+    """Test that both numeric (precision/temp_step) and time values are normalized.
+
+    Issue #468 required precision/temp_step string-to-float conversion.
+    Issue #484 requires keep_alive float-to-timedelta conversion.
+    Both should work together.
+    """
+    setup_sensor(hass, 22.0)
+    setup_switch(hass, False, common.ENT_HEATER)
+
+    # Simulate config with both string numeric and float time values
+    config_data = {
+        "name": "test",
+        CONF_HEATER: common.ENT_HEATER,
+        CONF_SENSOR: common.ENT_SENSOR,
+        CONF_COLD_TOLERANCE: 0.5,
+        CONF_HOT_TOLERANCE: 0.5,
+        "precision": "0.5",  # String from SelectSelector (issue #468)
+        "target_temp_step": "0.5",  # String from SelectSelector (issue #468)
+        CONF_KEEP_ALIVE: 300.0,  # Float from NumberSelector (issue #484)
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        title="test",
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify entity was created successfully with both normalizations applied
+    state = hass.states.get(common.ENTITY)
+    assert state is not None
+    assert state.state == "off"
+    # Precision should be 0.5 (from string conversion)
+    assert state.attributes["target_temp_step"] == 0.5


### PR DESCRIPTION
## Summary

Fixes the second part of issue #484 where entities fail to mount in HA when `keep_alive`, `min_cycle_duration`, or `stale_duration` are configured via the config flow UI.

## Problem

When time-based settings are configured via config flow:
1. **Config flow stores**: Numeric values (int/float) in seconds because NumberSelector returns numbers
2. **climate.py expects**: timedelta objects
3. **Result**: `AttributeError: 'float' object has no attribute 'total_seconds'` when calling `async_track_time_interval()`

This prevented entities from being created after completing config flow.

## Root Cause

```python
# Config flow stores (NumberSelector):
{"keep_alive": 300.0}  # float, not timedelta

# climate.py line 752 expects:
async_track_time_interval(
    self.hass,
    self._async_control_climate,
    self._keep_alive,  # Expected: timedelta(seconds=300)
)
```

When Home Assistant's `async_track_time_interval` receives a float, it tries to call `.total_seconds()` → crash.

## Solution

Extended `_normalize_config_numeric_values()` in `climate.py` to convert time-based config values:

```python
# Time-based keys that need conversion from seconds to timedelta
time_keys = [CONF_KEEP_ALIVE, CONF_MIN_DUR, CONF_STALE_DURATION]

for key in time_keys:
    if key in config and config[key] is not None:
        value = config[key]
        if not isinstance(value, timedelta):
            if isinstance(value, (int, float)):
                config[key] = timedelta(seconds=value)
```

This:
- ✅ Converts int/float (seconds) to timedelta during entity setup
- ✅ Preserves existing timedelta values (for YAML configs)
- ✅ Handles all time-based settings: `keep_alive`, `min_cycle_duration`, `stale_duration`

## Testing

Added 5 comprehensive tests in `tests/edge_cases/test_issue_484_keep_alive_timedelta.py`:

1. ✅ `test_keep_alive_float_converted_to_timedelta` - Main fix validation
2. ✅ `test_min_cycle_duration_int_converted_to_timedelta` - Min cycle support
3. ✅ `test_stale_duration_float_converted_to_timedelta` - Stale duration support
4. ✅ `test_timedelta_values_preserved` - YAML compatibility
5. ✅ `test_mixed_numeric_and_time_normalization` - Combined with #468 fix

Each test:
- Creates a config entry with time values as int/float (simulating config flow)
- Verifies entity is created successfully without AttributeError
- Confirms the fix doesn't break existing functionality

## Impact

- ✅ Fixes entity creation failures when time-based settings configured via UI
- ✅ All 1245 existing tests pass + 5 new tests
- ✅ Works for all system types
- ✅ No breaking changes - preserves timedelta values from YAML configs
- ✅ Linting passes (isort, black, flake8)

## Note

This fix addresses the **second part** of issue #484. The first part (precision/temp_step/target_temp persistence) was fixed in PR #486 which has already been merged.

Fixes #484

