### PR TITLE
fix: correct logger name handling for multiple thermostat instances

### DIFF
--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -593,8 +593,6 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         self._template_listeners: list[Callable[[], None]] = []
         self._active_preset_entities: set[str] = set()
 
-        _LOGGER.name = __name__ + "." + self.unique_id if self.unique_id else __name__
-
     async def _setup_template_listeners(self) -> None:
         """Set up listeners for entities referenced in active preset templates."""
         # Remove existing listeners first
@@ -1136,16 +1134,18 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         self, hvac_mode: HVACMode, is_restore: bool = False
     ) -> None:
         """Call climate mode based on current mode."""
-        _LOGGER.info("Setting hvac mode: %s", hvac_mode)
+        _LOGGER.info("%s: Setting hvac mode: %s", self.entity_id, hvac_mode)
 
         if hvac_mode not in self.hvac_modes:
-            _LOGGER.debug("Unrecognized hvac mode: %s", hvac_mode)
+            _LOGGER.debug("%s: Unrecognized hvac mode: %s", self.entity_id, hvac_mode)
             return
 
         if hvac_mode == HVACMode.OFF:
             self._last_hvac_mode = self.hvac_device.hvac_mode
             _LOGGER.info(
-                "Turning off with saving last hvac mode: %s", self._last_hvac_mode
+                "%s: Turning off with saving last hvac mode: %s",
+                self.entity_id,
+                self._last_hvac_mode,
             )
 
         self._hvac_mode = hvac_mode

--- a/tests/test_logger_multiple_instances.py
+++ b/tests/test_logger_multiple_instances.py
@@ -1,0 +1,197 @@
+"""Test logger behavior with multiple thermostat instances."""
+
+import logging
+
+from homeassistant.components.climate import HVACMode
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dual_smart_thermostat.climate import DOMAIN
+from custom_components.dual_smart_thermostat.const import (
+    CONF_HEATER,
+    CONF_SENSOR,
+    CONF_TARGET_TEMP,
+)
+
+
+@pytest.mark.asyncio
+async def test_multiple_thermostats_logger_names(hass: HomeAssistant, caplog):
+    """Test that multiple thermostat instances have correct logger names in logs.
+
+    This test reproduces issue #511 where the logger name is incorrectly set
+    to the last initialized thermostat's unique_id, causing confusion when
+    troubleshooting logs for multiple thermostats.
+    """
+    # Mock the heater and sensor entities BEFORE creating config entries
+    hass.states.async_set("switch.living_heater", "off")
+    hass.states.async_set(
+        "sensor.living_temp", "20", {"unit_of_measurement": UnitOfTemperature.CELSIUS}
+    )
+    hass.states.async_set("switch.master_heater", "off")
+    hass.states.async_set(
+        "sensor.master_temp", "20", {"unit_of_measurement": UnitOfTemperature.CELSIUS}
+    )
+
+    # Create and set up first thermostat - "living"
+    living_config = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Living",
+            CONF_HEATER: "switch.living_heater",
+            CONF_SENSOR: "sensor.living_temp",
+            CONF_TARGET_TEMP: 22,
+        },
+        unique_id="living",
+        title="Living",
+        entry_id="living_entry",
+    )
+    living_config.add_to_hass(hass)
+    await hass.config_entries.async_setup(living_config.entry_id)
+    await hass.async_block_till_done()
+
+    # Create and set up second thermostat - "master"
+    master_config = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Master",
+            CONF_HEATER: "switch.master_heater",
+            CONF_SENSOR: "sensor.master_temp",
+            CONF_TARGET_TEMP: 22,
+        },
+        unique_id="master",
+        title="Master",
+        entry_id="master_entry",
+    )
+    master_config.add_to_hass(hass)
+    await hass.config_entries.async_setup(master_config.entry_id)
+    await hass.async_block_till_done()
+
+    # Get the climate entities
+    living_entity_id = "climate.living"
+    master_entity_id = "climate.master"
+
+    # Clear logs
+    caplog.clear()
+
+    # Trigger an action on the living thermostat
+    with caplog.at_level(logging.INFO):
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": living_entity_id, "hvac_mode": HVACMode.HEAT},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    # Check that logs for living thermostat include the entity_id in the message
+    living_logs = [
+        record for record in caplog.records if "Setting hvac mode" in record.message
+    ]
+
+    assert len(living_logs) > 0, "Expected to find log messages for setting HVAC mode"
+
+    # Verify the log message includes the correct entity_id
+    log_message = living_logs[0].message
+    assert living_entity_id in log_message, (
+        f"Log message should include entity_id '{living_entity_id}', "
+        f"but got: {log_message}"
+    )
+
+    # Clear logs and test master thermostat
+    caplog.clear()
+
+    with caplog.at_level(logging.INFO):
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": master_entity_id, "hvac_mode": HVACMode.HEAT},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    master_logs = [
+        record for record in caplog.records if "Setting hvac mode" in record.message
+    ]
+
+    assert len(master_logs) > 0, "Expected to find log messages for master thermostat"
+
+    # Verify the log message includes the correct entity_id for master
+    log_message = master_logs[0].message
+    assert master_entity_id in log_message, (
+        f"Log message should include entity_id '{master_entity_id}', "
+        f"but got: {log_message}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_logger_name_not_overridden(hass: HomeAssistant):
+    """Test that logger name remains consistent across multiple thermostat instances.
+
+    This test verifies the fix for issue #511 where the logger name was incorrectly
+    overridden by the last initialized thermostat's unique_id.
+    """
+    from custom_components.dual_smart_thermostat import climate
+
+    # Get the module-level logger
+    original_logger_name = climate._LOGGER.name
+
+    # Set up entities FIRST
+    hass.states.async_set("switch.living_heater", "off")
+    hass.states.async_set(
+        "sensor.living_temp", "20", {"unit_of_measurement": UnitOfTemperature.CELSIUS}
+    )
+    hass.states.async_set("switch.master_heater", "off")
+    hass.states.async_set(
+        "sensor.master_temp", "20", {"unit_of_measurement": UnitOfTemperature.CELSIUS}
+    )
+
+    # Create and set up first thermostat
+    living_config = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Living",
+            CONF_HEATER: "switch.living_heater",
+            CONF_SENSOR: "sensor.living_temp",
+            CONF_TARGET_TEMP: 22,
+        },
+        unique_id="living",
+        title="Living",
+        entry_id="living_entry",
+    )
+    living_config.add_to_hass(hass)
+    await hass.config_entries.async_setup(living_config.entry_id)
+    await hass.async_block_till_done()
+
+    # Check logger name after first thermostat - should remain unchanged
+    logger_name_after_living = climate._LOGGER.name
+    assert logger_name_after_living == original_logger_name
+
+    # Create and set up second thermostat
+    master_config = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Master",
+            CONF_HEATER: "switch.master_heater",
+            CONF_SENSOR: "sensor.master_temp",
+            CONF_TARGET_TEMP: 22,
+        },
+        unique_id="master",
+        title="Master",
+        entry_id="master_entry",
+    )
+    master_config.add_to_hass(hass)
+    await hass.config_entries.async_setup(master_config.entry_id)
+    await hass.async_block_till_done()
+
+    # FIX: Logger name should still be the original, not overridden
+    logger_name_after_master = climate._LOGGER.name
+
+    # Verify the logger name hasn't changed
+    assert logger_name_after_master == original_logger_name
+    assert logger_name_after_master == logger_name_after_living
+
+    # Logger name should be the module name, not contain instance-specific IDs
+    assert "living" not in logger_name_after_master
+    assert "master" not in logger_name_after_master


### PR DESCRIPTION
## Summary
Fixes #511 - Resolves incorrect logger names when multiple thermostat instances are configured.

## Problem
When multiple thermostats were configured, all log messages showed the logger name of the last initialized thermostat, making it confusing to troubleshoot issues with specific thermostats.

### Example Issue
With two thermostats ("living" and "master"), logs from **both** showed:
```
[custom_components.dual_smart_thermostat.climate.master] turned on with hvac mode: heat_cool
```
Even when the action was from the "living" thermostat.

## Root Cause
- `_LOGGER` is defined at module scope and shared by all thermostat instances
- Line 596 in `climate.py` modified `_LOGGER.name` with each instance's `unique_id`
- This caused a "last instance wins" behavior where all instances used the same logger name

## Solution
1. **Removed logger name override** - Deleted the problematic line that modified `_LOGGER.name`
2. **Added entity_id to log messages** - Updated important log messages to explicitly include `self.entity_id` for identification
3. **Added comprehensive tests** - Created `test_logger_multiple_instances.py` to verify the fix

## Changes

### `custom_components/dual_smart_thermostat/climate.py`
- Removed line 596: `_LOGGER.name = __name__ + "." + self.unique_id`
- Updated log messages in `async_set_hvac_mode()` to include `self.entity_id`:
  - `_LOGGER.info("%s: Setting hvac mode: %s", self.entity_id, hvac_mode)`
  - `_LOGGER.debug("%s: Unrecognized hvac mode: %s", self.entity_id, hvac_mode)`
  - `_LOGGER.info("%s: Turning off with saving last hvac mode: %s", self.entity_id, ...)`

### `tests/test_logger_multiple_instances.py` (NEW)
- `test_multiple_thermostats_logger_names`: Verifies log messages include correct entity_id
- `test_logger_name_not_overridden`: Verifies logger name stays consistent across instances

## Impact

### Before
```
Logger name: custom_components.dual_smart_thermostat.climate.master  (for ALL instances)
Log message: Setting hvac mode: heat
```

### After
```
Logger name: custom_components.dual_smart_thermostat.climate  (consistent)
Log message: climate.living: Setting hvac mode: heat
```

## Benefits
- ✅ Clear identification of which thermostat is logging
- ✅ Follows Home Assistant logging best practices
- ✅ No breaking changes
- ✅ Minimal code changes (low regression risk)

## Testing
- ✅ All 1296 existing tests pass
- ✅ 2 new tests added and passing
- ✅ Linting passes (isort, black, flake8, mypy, codespell)
- ✅ Pre-commit hooks pass

## Test Plan
Users with multiple thermostats can verify that:
1. Log messages now show the correct `entity_id` for each thermostat
2. Logs are easier to filter and debug by specific thermostat
3. No functional changes to thermostat behavior