### PR TITLE
fix: apply tolerance selector fix to options flow (Runtime Tuning)

### DIFF
--- a/custom_components/dual_smart_thermostat/options_flow.py
+++ b/custom_components/dual_smart_thermostat/options_flow.py
@@ -55,7 +55,7 @@ from .feature_steps import (
     OpeningsSteps,
     PresetsSteps,
 )
-from .schema_utils import get_temperature_selector
+from .schema_utils import get_tolerance_selector
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -202,9 +202,7 @@ class OptionsFlowHandler(OptionsFlow):
                 CONF_COLD_TOLERANCE,
                 description={"suggested_value": cold_tol},
             )
-        ] = get_temperature_selector(
-            hass=self.hass, min_value=0, max_value=10, step=0.1
-        )
+        ] = get_tolerance_selector(hass=self.hass, min_value=0, max_value=10, step=0.1)
 
         hot_tol = current_config.get(CONF_HOT_TOLERANCE, 0.3)
         _LOGGER.debug(
@@ -217,9 +215,7 @@ class OptionsFlowHandler(OptionsFlow):
                 CONF_HOT_TOLERANCE,
                 description={"suggested_value": hot_tol},
             )
-        ] = get_temperature_selector(
-            hass=self.hass, min_value=0, max_value=10, step=0.1
-        )
+        ] = get_tolerance_selector(hass=self.hass, min_value=0, max_value=10, step=0.1)
 
         # === TEMPERATURE LIMITS (always shown) ===
         # Use suggested_value instead of default to avoid saving defaults when not changed
@@ -441,7 +437,7 @@ class OptionsFlowHandler(OptionsFlow):
                         "suggested_value": current_config.get(CONF_HEAT_TOLERANCE)
                     },
                 )
-            ] = get_temperature_selector(
+            ] = get_tolerance_selector(
                 hass=self.hass, min_value=0, max_value=5.0, step=0.1
             )
 
@@ -452,7 +448,7 @@ class OptionsFlowHandler(OptionsFlow):
                         "suggested_value": current_config.get(CONF_COOL_TOLERANCE)
                     },
                 )
-            ] = get_temperature_selector(
+            ] = get_tolerance_selector(
                 hass=self.hass, min_value=0, max_value=5.0, step=0.1
             )
 

--- a/custom_components/dual_smart_thermostat/schemas.py
+++ b/custom_components/dual_smart_thermostat/schemas.py
@@ -1050,24 +1050,16 @@ def get_advanced_settings_schema(hass=None):
             ),
             vol.Optional(
                 CONF_COLD_TOLERANCE, default=DEFAULT_TOLERANCE
-            ): get_temperature_selector(
-                hass=hass, min_value=0, max_value=10, step=0.05
-            ),
+            ): get_tolerance_selector(hass=hass, min_value=0, max_value=10, step=0.05),
             vol.Optional(
                 CONF_HOT_TOLERANCE, default=DEFAULT_TOLERANCE
-            ): get_temperature_selector(
-                hass=hass, min_value=0, max_value=10, step=0.05
-            ),
+            ): get_tolerance_selector(hass=hass, min_value=0, max_value=10, step=0.05),
             vol.Optional(
                 CONF_HEAT_TOLERANCE, default=DEFAULT_TOLERANCE
-            ): get_temperature_selector(
-                hass=hass, min_value=0, max_value=5.0, step=0.05
-            ),
+            ): get_tolerance_selector(hass=hass, min_value=0, max_value=5.0, step=0.05),
             vol.Optional(
                 CONF_COOL_TOLERANCE, default=DEFAULT_TOLERANCE
-            ): get_temperature_selector(
-                hass=hass, min_value=0, max_value=5.0, step=0.05
-            ),
+            ): get_tolerance_selector(hass=hass, min_value=0, max_value=5.0, step=0.05),
             # Convert seconds to duration dict format for DurationSelector
             vol.Optional(
                 CONF_MIN_DUR, default=seconds_to_duration(300)


### PR DESCRIPTION
## Summary
- Extends #523 fix to cover the **Options Flow** (Runtime Tuning settings)
- The previous PR fixed the config flow but missed the options flow where users edit tolerance values after initial setup

## Changes
Updated `get_tolerance_selector` usage in:
- `options_flow.py`: cold_tolerance, hot_tolerance, heat_tolerance, cool_tolerance
- `schemas.py` `get_advanced_settings_schema()`: all four tolerance fields

## Test plan
- [x] All 214 config flow tests pass
- [x] All 7 schema_utils unit tests pass
- [ ] Manual testing: Edit thermostat settings in Fahrenheit mode and verify tolerance accepts values < 32