### PR TITLE
fix: Secondary Heater does not turn off with primary heater

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ If the third [`secondary heater_dual_mode`](#secondar_heater_dual_mode) is set t
 
 ```yaml
 secondary_heater: switch.study_secondary_heater   # <-- required
-secondary_heater_timeout: 00:00:30                 # <-- required
-secondary_heater_timeout: true                   # <-- optional
+secondary_heater_timeout: 00:00:30                # <-- required
+secondary_heater_dual_mode: true                  # <-- optional
 ```
 
 ## Fan Only Mode


### PR DESCRIPTION
When using secondary_heater_dual_mode with heat_cool_mode, the secondary heater was not being turned off when the target temperature was reached. This was because the else branch in _async_control_devices_when_on() delegated to heater_device.async_control_hvac(), which would turn off the primary heater independently without also turning off the aux heater.

Fixed by handling the keep-alive case directly instead of delegating to the inner heater device.

Fixes #533

Also fixed a typo in the example config relating to secondary_heaters, where _timeout was included twice - changed to include _dual_mode instead