### PR TITLE
fix: secondary heater not turning off with primary in dual mode

### DIFF
--- a/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
@@ -74,9 +74,7 @@ class MultiHvacDevice(HVACDevice, ControlableHVACDevice):
     @hvac_mode.setter
     def hvac_mode(self, hvac_mode: HVACMode):
         self._hvac_mode = hvac_mode
-        if hvac_mode == HVACMode.OFF:
-            for device in self.hvac_devices:
-                device.hvac_mode = HVACMode.OFF
+        self.set_sub_devices_hvac_mode(hvac_mode)
 
     @property
     def hvac_action(self) -> HVACAction:


### PR DESCRIPTION
## Summary

Fixes #533 — In HEAT_COOL mode with heater+cooler+secondary_heater in dual mode, both heaters stayed ON indefinitely between target temperature and target+tolerance.

Two bugs contributed to this:

- **Mode propagation gap**: `MultiHvacDevice.hvac_mode` setter only propagated `OFF` to children, so the inner `HeaterDevice` (inside `HeaterAUXHeaterDevice`) kept `hvac_mode=OFF` and skipped all control logic. Fixed by always propagating via `set_sub_devices_hvac_mode()`.

- **Aux heater turn-off gap**: `HeaterAUXHeaterDevice._async_control_devices_when_on()` else branch only delegated to the primary heater but never turned off the aux heater when the primary turned off. Fixed by checking if the primary heater was turned off by the control call and turning off the aux heater accordingly.

## Test plan

- [x] 4 edge case tests for issue #533 (non-dual turn-off, dual turn-off together, secondary not left on, HEAT_COOL mode)
- [x] Full heater mode test suite (118 passed)
- [x] Full dual mode test suite (220 passed)
- [x] Full test suite (1346 passed, 2 skipped)
- [x] Lint checks (isort, black, flake8, ruff, codespell, mypy)