### PR TITLE
fix: use tolerance selector in get_core_schema() for cold/hot tolerance (#526)

### DIFF
--- a/custom_components/dual_smart_thermostat/config_flow.py
+++ b/custom_components/dual_smart_thermostat/config_flow.py
@@ -332,7 +332,10 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 "custom_components.dual_smart_thermostat.schemas",
                 fromlist=["get_core_schema"],
             ).get_core_schema(
-                system_type, defaults=self.collected_config, include_name=True
+                system_type,
+                defaults=self.collected_config,
+                include_name=True,
+                hass=self.hass,
             )
 
         return self.async_show_form(step_id="basic", data_schema=schema, errors=errors)

--- a/custom_components/dual_smart_thermostat/schemas.py
+++ b/custom_components/dual_smart_thermostat/schemas.py
@@ -781,7 +781,10 @@ def get_system_features_schema(system_type: str):
 
 
 def get_core_schema(
-    system_type: str, defaults: dict[str, Any] | None = None, include_name: bool = True
+    system_type: str,
+    defaults: dict[str, Any] | None = None,
+    include_name: bool = True,
+    hass=None,
 ):
     """Build the core configuration schema used by both config and options flows.
 
@@ -858,13 +861,13 @@ def get_core_schema(
             CONF_COLD_TOLERANCE,
             default=defaults.get(CONF_COLD_TOLERANCE, DEFAULT_TOLERANCE),
         )
-    ] = get_percentage_selector()
+    ] = get_tolerance_selector(hass=hass, min_value=0, max_value=10, step=0.05)
     schema_dict[
         vol.Optional(
             CONF_HOT_TOLERANCE,
             default=defaults.get(CONF_HOT_TOLERANCE, DEFAULT_TOLERANCE),
         )
-    ] = get_percentage_selector()
+    ] = get_tolerance_selector(hass=hass, min_value=0, max_value=10, step=0.05)
     # Convert seconds to duration dict format for DurationSelector
     min_dur_default = (
         seconds_to_duration(defaults.get(CONF_MIN_DUR))

--- a/tests/unit/test_schema_utils.py
+++ b/tests/unit/test_schema_utils.py
@@ -6,11 +6,17 @@ Tests the schema utility functions that create selectors for config/options flow
 from unittest.mock import MagicMock
 
 from homeassistant.const import UnitOfTemperature
+import pytest
 
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COLD_TOLERANCE,
+    CONF_HOT_TOLERANCE,
+)
 from custom_components.dual_smart_thermostat.schema_utils import (
     get_temperature_selector,
     get_tolerance_selector,
 )
+from custom_components.dual_smart_thermostat.schemas import get_core_schema
 
 
 class TestGetToleranceSelector:
@@ -169,3 +175,97 @@ class TestToleranceVsTemperatureComparison:
 
         # Temperature: 0°C absolute becomes 32°F
         assert temperature_selector.config["min"] == 32
+
+
+class TestGetCoreSchemaToleranceSelectors:
+    """Test that get_core_schema uses tolerance selectors (not percentage) for tolerance fields.
+
+    Issue #526: Tolerance fields were incorrectly using get_percentage_selector()
+    (0–100% range) instead of get_tolerance_selector() (temperature delta, 0–10°C).
+    Percentage selectors show % unit and reject small values in Fahrenheit.
+    """
+
+    @pytest.mark.parametrize("system_type", ["heat_pump", "heater_cooler", "ac_only"])
+    def test_cold_tolerance_uses_tolerance_selector_not_percentage(self, system_type):
+        """Test that cold_tolerance field uses tolerance selector, not percentage.
+
+        The tolerance selector uses °C/°F/° units and a max of 10.
+        The percentage selector uses % unit and a max of 100.
+        """
+        hass = MagicMock()
+        hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+
+        schema = get_core_schema(system_type, defaults={}, hass=hass)
+
+        cold_tol_selector = None
+        for key, value in schema.schema.items():
+            if hasattr(key, "schema") and key.schema == CONF_COLD_TOLERANCE:
+                cold_tol_selector = value
+                break
+
+        assert (
+            cold_tol_selector is not None
+        ), f"cold_tolerance field not found in get_core_schema for {system_type}"
+        assert cold_tol_selector.config.get("unit_of_measurement") != "%", (
+            f"cold_tolerance should not use percentage selector for {system_type}. "
+            "Tolerances are temperature deltas, not percentages."
+        )
+        assert cold_tol_selector.config.get("max", 100) <= 20, (
+            f"cold_tolerance max should be <= 20 for {system_type}, "
+            f"got {cold_tol_selector.config.get('max')}. "
+            "A max of 100 indicates a percentage selector is being used."
+        )
+
+    @pytest.mark.parametrize("system_type", ["heat_pump", "heater_cooler", "ac_only"])
+    def test_hot_tolerance_uses_tolerance_selector_not_percentage(self, system_type):
+        """Test that hot_tolerance field uses tolerance selector, not percentage."""
+        hass = MagicMock()
+        hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+
+        schema = get_core_schema(system_type, defaults={}, hass=hass)
+
+        hot_tol_selector = None
+        for key, value in schema.schema.items():
+            if hasattr(key, "schema") and key.schema == CONF_HOT_TOLERANCE:
+                hot_tol_selector = value
+                break
+
+        assert (
+            hot_tol_selector is not None
+        ), f"hot_tolerance field not found in get_core_schema for {system_type}"
+        assert hot_tol_selector.config.get("unit_of_measurement") != "%", (
+            f"hot_tolerance should not use percentage selector for {system_type}. "
+            "Tolerances are temperature deltas, not percentages."
+        )
+        assert hot_tol_selector.config.get("max", 100) <= 20, (
+            f"hot_tolerance max should be <= 20 for {system_type}, "
+            f"got {hot_tol_selector.config.get('max')}. "
+            "A max of 100 indicates a percentage selector is being used."
+        )
+
+    @pytest.mark.parametrize("system_type", ["heat_pump", "heater_cooler", "ac_only"])
+    def test_cold_tolerance_fahrenheit_uses_scaled_delta(self, system_type):
+        """Test that cold_tolerance is correctly scaled for Fahrenheit users.
+
+        A 0–10°C delta range should become 0–18°F (multiply by 1.8),
+        NOT 32–50°F (absolute temperature conversion).
+        This ensures Fahrenheit users can enter small tolerance values.
+        """
+        hass = MagicMock()
+        hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+
+        schema = get_core_schema(system_type, defaults={}, hass=hass)
+
+        cold_tol_selector = None
+        for key, value in schema.schema.items():
+            if hasattr(key, "schema") and key.schema == CONF_COLD_TOLERANCE:
+                cold_tol_selector = value
+                break
+
+        assert cold_tol_selector is not None
+        # min must be 0 (not 32 which would come from absolute °C→°F conversion)
+        assert cold_tol_selector.config.get("min") == 0, (
+            f"cold_tolerance min in Fahrenheit should be 0 (delta scaling), "
+            f"got {cold_tol_selector.config.get('min')}. "
+            "A min of 32 indicates incorrect absolute temperature conversion."
+        )


### PR DESCRIPTION
## Summary

- `get_core_schema()` was using `get_percentage_selector()` (0–100%, `%` unit) for `cold_tolerance` and `hot_tolerance` fields instead of `get_tolerance_selector()`
- Added `hass` parameter to `get_core_schema()` so Fahrenheit delta scaling (×1.8) works correctly, matching all other schema functions
- Updated the `config_flow.py` call site to pass `hass=self.hass`

## Root cause

Tolerances are temperature **deltas**, not absolute temperatures and not percentages. Using `get_percentage_selector()` displays a 0–100% range and `%` unit, which is semantically wrong and confusing. The previous fixes (#529, #530) correctly updated `options_flow.py` and the individual system schema functions (`get_simple_heater_schema`, `get_heater_cooler_schema`, etc.) but missed `get_core_schema()`.

## Test plan

- [x] Added 9 new unit tests in `tests/unit/test_schema_utils.py` covering `heat_pump`, `heater_cooler`, and `ac_only` system types
- [x] Tests verify `%` unit is not used and max ≤ 20 (not 100)
- [x] Tests verify Fahrenheit delta scaling: min stays 0 (not 32 from absolute conversion)
- [x] Full test suite passes: 1355 passed, 2 skipped
- [x] All linting checks pass