### PR TITLE
fix: evaluate template-based preset temperatures before applying (#538)

### DIFF
--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -766,6 +766,12 @@ class EnvironmentManager(StateManager):
             "Setting temperatures from hvac mode and presets when have preset mode. is_range_mode: %s",
             is_range_mode,
         )
+
+        # Use template-aware getters to evaluate templates (#538)
+        preset_temp = preset_env.get_temperature(self.hass)
+        preset_temp_low = preset_env.get_target_temp_low(self.hass)
+        preset_temp_high = preset_env.get_target_temp_high(self.hass)
+
         if is_range_mode:
             _LOGGER.debug(
                 "Setting temperatures from preset range mode, preset_env: %s",
@@ -773,8 +779,8 @@ class EnvironmentManager(StateManager):
             )
 
             if preset_env.has_temp_range():
-                self.target_temp_low = preset_env.to_dict[ATTR_TARGET_TEMP_LOW]
-                self.target_temp_high = preset_env.to_dict[ATTR_TARGET_TEMP_HIGH]
+                self.target_temp_low = preset_temp_low
+                self.target_temp_high = preset_temp_high
 
         else:
             _LOGGER.debug(
@@ -789,21 +795,21 @@ class EnvironmentManager(StateManager):
 
                 # we prioritize the target temp from preset if it is set
                 if preset_env.has_temp():
-                    self.target_temp = preset_env.to_dict[ATTR_TEMPERATURE]
+                    self.target_temp = preset_temp
                 # only after that we check if the temp range is set
                 elif preset_env.has_temp_range():
                     if hvac_mode == HVACMode.HEAT:
                         _LOGGER.debug(
                             "Setting temperatures from preset target mode if HVACMode.HEAT. Preset: %s",
-                            preset_env.to_dict[ATTR_TARGET_TEMP_LOW],
+                            preset_temp_low,
                         )
-                        self.target_temp = preset_env.to_dict[ATTR_TARGET_TEMP_LOW]
+                        self.target_temp = preset_temp_low
                     elif hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY]:
                         _LOGGER.debug(
                             "Setting temperatures from preset target mode if HVACMode.COOL, HVACMode.FAN_ONLY. Preset: %s",
-                            preset_env.to_dict[ATTR_TARGET_TEMP_HIGH],
+                            preset_temp_high,
                         )
-                        self.target_temp = preset_env.to_dict[ATTR_TARGET_TEMP_HIGH]
+                        self.target_temp = preset_temp_high
 
                 return
 
@@ -824,20 +830,20 @@ class EnvironmentManager(StateManager):
                 if hvac_mode == HVACMode.HEAT:
                     _LOGGER.debug(
                         "Setting temperatures from preset range mode if HVACMode.HEAT. Preset: %s",
-                        preset_env.to_dict[ATTR_TARGET_TEMP_LOW],
+                        preset_temp_low,
                     )
-                    self._target_temp = preset_env.to_dict[ATTR_TARGET_TEMP_LOW]
+                    self._target_temp = preset_temp_low
                 elif hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY]:
                     _LOGGER.debug(
                         "Setting temperatures from preset range mode if HVACMode.COOL, HVACMode.FAN_ONLY. Preset: %s, sved_target_temp: %s",
-                        preset_env.to_dict[ATTR_TARGET_TEMP_HIGH],
+                        preset_temp_high,
                         self._saved_target_temp,
                     )
                     preset_match_old = old_preset_mode == preset_mode
                     self._target_temp = (
                         self._saved_target_temp
                         if preset_match_old and self._saved_target_temp
-                        else preset_env.to_dict[ATTR_TARGET_TEMP_HIGH]
+                        else preset_temp_high
                     )
                 else:
                     _LOGGER.debug("Setting target temp from preset, unhandled case")

--- a/tests/managers/test_environment_manager.py
+++ b/tests/managers/test_environment_manager.py
@@ -1,6 +1,11 @@
 """Tests for EnvironmentManager tolerance selection logic."""
 
-from homeassistant.components.climate.const import HVACMode
+from homeassistant.components.climate.const import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE
 import pytest
 
 from custom_components.dual_smart_thermostat.const import (
@@ -13,6 +18,7 @@ from custom_components.dual_smart_thermostat.const import (
 from custom_components.dual_smart_thermostat.managers.environment_manager import (
     EnvironmentManager,
 )
+from custom_components.dual_smart_thermostat.preset_env.preset_env import PresetEnv
 
 
 @pytest.fixture
@@ -291,3 +297,118 @@ class TestIsTooHotWithModeAwareness:
         env._cur_temp = 22.49
         # 22.49 >= 22.0 + 0.5 -> 22.49 >= 22.5 -> False
         assert env.is_too_hot() is False
+
+
+class TestSetTempsFromPresetWithTemplates:
+    """Test that set_temepratures_from_hvac_mode_and_presets evaluates templates.
+
+    Regression tests for #538: template-based preset temperatures were passed
+    as raw template strings instead of being evaluated to float values.
+    """
+
+    @pytest.mark.asyncio
+    async def test_template_preset_target_temp_evaluated(
+        self, hass, basic_config, setup_template_test_entities
+    ):
+        """Test template preset evaluates to float for single target temp (#538)."""
+        setup_template_test_entities
+        env = EnvironmentManager(hass, basic_config)
+        env._saved_target_temp = 20.0
+
+        template_str = "{{ states('input_number.away_temp') | float }}"
+        preset_env = PresetEnv(**{ATTR_TEMPERATURE: template_str})
+
+        env.set_temepratures_from_hvac_mode_and_presets(
+            hvac_mode=HVACMode.HEAT,
+            supports_temp_range=False,
+            preset_mode="away",
+            preset_env=preset_env,
+            is_range_mode=False,
+        )
+
+        # Must be float 18.0, NOT the raw template string
+        assert env.target_temp == 18.0
+        assert isinstance(env.target_temp, float)
+
+    @pytest.mark.asyncio
+    async def test_template_preset_range_temps_evaluated(
+        self, hass, basic_config, setup_template_test_entities
+    ):
+        """Test template preset evaluates to floats for range temps (#538)."""
+        setup_template_test_entities
+        env = EnvironmentManager(hass, basic_config)
+
+        preset_env = PresetEnv(
+            **{
+                ATTR_TARGET_TEMP_LOW: "{{ states('input_number.away_temp') | float }}",
+                ATTR_TARGET_TEMP_HIGH: "{{ states('input_number.comfort_temp') | float }}",
+            }
+        )
+
+        env.set_temepratures_from_hvac_mode_and_presets(
+            hvac_mode=HVACMode.HEAT_COOL,
+            supports_temp_range=True,
+            preset_mode="away",
+            preset_env=preset_env,
+            is_range_mode=True,
+        )
+
+        # Must be evaluated floats, NOT raw template strings
+        assert env.target_temp_low == 18.0
+        assert env.target_temp_high == 22.0
+        assert isinstance(env.target_temp_low, float)
+        assert isinstance(env.target_temp_high, float)
+
+    @pytest.mark.asyncio
+    async def test_template_preset_range_fallback_to_heat(
+        self, hass, basic_config, setup_template_test_entities
+    ):
+        """Test template range preset falls back to temp_low for HEAT mode (#538)."""
+        setup_template_test_entities
+        env = EnvironmentManager(hass, basic_config)
+
+        preset_env = PresetEnv(
+            **{
+                ATTR_TARGET_TEMP_LOW: "{{ states('input_number.away_temp') | float }}",
+                ATTR_TARGET_TEMP_HIGH: "{{ states('input_number.comfort_temp') | float }}",
+            }
+        )
+
+        env.set_temepratures_from_hvac_mode_and_presets(
+            hvac_mode=HVACMode.HEAT,
+            supports_temp_range=False,
+            preset_mode="away",
+            preset_env=preset_env,
+            is_range_mode=False,
+        )
+
+        # Should use temp_low (18.0) for HEAT mode, evaluated from template
+        assert env.target_temp == 18.0
+        assert isinstance(env.target_temp, float)
+
+    @pytest.mark.asyncio
+    async def test_template_preset_range_fallback_to_cool(
+        self, hass, basic_config, setup_template_test_entities
+    ):
+        """Test template range preset falls back to temp_high for COOL mode (#538)."""
+        setup_template_test_entities
+        env = EnvironmentManager(hass, basic_config)
+
+        preset_env = PresetEnv(
+            **{
+                ATTR_TARGET_TEMP_LOW: "{{ states('input_number.away_temp') | float }}",
+                ATTR_TARGET_TEMP_HIGH: "{{ states('input_number.comfort_temp') | float }}",
+            }
+        )
+
+        env.set_temepratures_from_hvac_mode_and_presets(
+            hvac_mode=HVACMode.COOL,
+            supports_temp_range=False,
+            preset_mode="away",
+            preset_env=preset_env,
+            is_range_mode=False,
+        )
+
+        # Should use temp_high (22.0) for COOL mode, evaluated from template
+        assert env.target_temp == 22.0
+        assert isinstance(env.target_temp, float)


### PR DESCRIPTION
## Summary

- Fixes #538: template-based preset temperatures (e.g., `{{ states('input_number.away_temp') | float }}`) were passed as raw strings instead of being evaluated to float values when activating a preset mode
- Replaced all `preset_env.to_dict[...]` temperature accesses in `_set_temps_when_have_preset_mode()` with template-aware getters (`get_temperature()`, `get_target_temp_low()`, `get_target_temp_high()`)

## Test plan

- [x] Added 4 regression tests in `TestSetTempsFromPresetWithTemplates` covering single target temp, range mode, and HEAT/COOL fallback paths
- [x] All 1359 tests pass
- [x] Linting clean