### PR TITLE
Fix preset floor temp examples to use nested format

### DIFF
--- a/examples/advanced_features/floor_heating_with_limits.yaml
+++ b/examples/advanced_features/floor_heating_with_limits.yaml
@@ -64,18 +64,21 @@ climate:
 #     max_floor_temp: 28
 #     min_floor_temp: 20
 #
-#     # Preset modes with custom floor limits
-#     away_temp: 16
-#     away_max_floor_temp: 25      # Lower max when away (save energy)
-#     away_min_floor_temp: 18      # Higher min when away (prevent freezing)
+#     # Preset modes with custom floor limits (nested format)
+#     away:
+#       temperature: 16
+#       max_floor_temp: 25           # Lower max when away (save energy)
+#       min_floor_temp: 18           # Higher min when away (prevent freezing)
 #
-#     eco_temp: 19
-#     eco_max_floor_temp: 26       # Moderate limits for eco mode
-#     eco_min_floor_temp: 19
+#     eco:
+#       temperature: 19
+#       max_floor_temp: 26           # Moderate limits for eco mode
+#       min_floor_temp: 19
 #
-#     comfort_temp: 21
-#     comfort_max_floor_temp: 30   # Higher max for comfort
-#     comfort_min_floor_temp: 22   # Higher min for comfort
+#     comfort:
+#       temperature: 21
+#       max_floor_temp: 30           # Higher max for comfort
+#       min_floor_temp: 22           # Higher min for comfort
 #
 #     initial_hvac_mode: "heat"
 

--- a/examples/advanced_features/presets_advanced.yaml
+++ b/examples/advanced_features/presets_advanced.yaml
@@ -110,15 +110,17 @@ climate:
 #     max_floor_temp: 28
 #     min_floor_temp: 20
 #
-#     # Away preset with conservative floor limits
-#     away_temp: 16
-#     away_max_floor_temp: 25  # Lower max to save energy
-#     away_min_floor_temp: 18  # Higher min to prevent freezing
+#     # Away preset with conservative floor limits (nested format)
+#     away:
+#       temperature: 16
+#       max_floor_temp: 25       # Lower max to save energy
+#       min_floor_temp: 18       # Higher min to prevent freezing
 #
 #     # Comfort preset with relaxed limits
-#     comfort_temp: 22
-#     comfort_max_floor_temp: 30  # Allow warmer floors
-#     comfort_min_floor_temp: 23  # Keep floors warm
+#     comfort:
+#       temperature: 22
+#       max_floor_temp: 30       # Allow warmer floors
+#       min_floor_temp: 23       # Keep floors warm
 #
 #     # Home preset uses global limits
 #     home_temp: 20

--- a/examples/advanced_features/presets_with_templates.yaml
+++ b/examples/advanced_features/presets_with_templates.yaml
@@ -543,14 +543,16 @@ climate:
 #     max_floor_temp: 28
 #     min_floor_temp: 20
 #
-#     # AWAY preset with template temperature and floor limits
-#     away_temp: "{{ 16 if is_state('sensor.season', 'winter') else 20 }}"
-#     away_max_floor_temp: 25  # Static floor limit for away
+#     # AWAY preset with template temperature and floor limits (nested format)
+#     away:
+#       temperature: "{{ 16 if is_state('sensor.season', 'winter') else 20 }}"
+#       max_floor_temp: 25       # Static floor limit for away
 #
 #     # ECO preset with template-based floor limits
-#     eco_temp: "{{ states('input_number.eco_target') | float }}"
-#     eco_max_floor_temp: "{{ states('input_number.eco_floor_max') | float }}"
-#     eco_min_floor_temp: "{{ states('input_number.eco_floor_min') | float }}"
+#     eco:
+#       temperature: "{{ states('input_number.eco_target') | float }}"
+#       max_floor_temp: "{{ states('input_number.eco_floor_max') | float }}"
+#       min_floor_temp: "{{ states('input_number.eco_floor_min') | float }}"
 #
 #     initial_hvac_mode: "heat"
 #


### PR DESCRIPTION
## Summary
- Fixes #544 - Examples used invalid flat keys like `away_max_floor_temp` that are not in the YAML platform schema
- Updated three example files to use the correct nested preset format with `temperature`, `max_floor_temp`, and `min_floor_temp` keys

## Files changed
- `examples/advanced_features/floor_heating_with_limits.yaml`
- `examples/advanced_features/presets_advanced.yaml`
- `examples/advanced_features/presets_with_templates.yaml`

## Test plan
- [x] Verify no remaining flat `*_max_floor_temp`/`*_min_floor_temp` keys in examples
- [x] Validate YAML syntax of updated examples