### PR TITLE
fix: prevent spurious turn_off on idle devices in heat_cool mode

### DIFF
--- a/custom_components/dual_smart_thermostat/hvac_device/heater_cooler_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/heater_cooler_device.py
@@ -175,14 +175,15 @@ class HeaterCoolerDevice(MultiHvacDevice):
         if too_cold:
             await self.heater_device.async_control_hvac(time, force)
             self._hvac_action_reason = self.heater_device.HVACActionReason
-            await self.cooler_device.async_turn_off()
+            if self.cooler_device.is_active:
+                await self.cooler_device.async_turn_off()
         elif too_hot:
             await self.cooler_device.async_control_hvac(time, force)
             self._hvac_action_reason = self.cooler_device.HVACActionReason
-            await self.heater_device.async_turn_off()
+            if self.heater_device.is_active:
+                await self.heater_device.async_turn_off()
         else:
-            await self.heater_device.async_turn_off()
-            await self.cooler_device.async_turn_off()
+            await self.async_turn_off_all(time)
             self._hvac_action_reason = HVACActionReason.TARGET_TEMP_REACHED
 
     async def _async_check_device_initial_state(self) -> None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 
+from homeassistant.components import input_boolean, input_number
 from homeassistant.components.climate import (
     DOMAIN as CLIMATE,
     PRESET_ACTIVITY,
@@ -1218,6 +1219,64 @@ async def setup_component(hass: HomeAssistant, mock_config: dict) -> MockConfigE
     await hass.async_block_till_done()
 
     return config_entry
+
+
+@pytest.fixture
+async def setup_comp_heat_cool_dual_switch(hass: HomeAssistant) -> None:
+    """Set up a heat-cool thermostat with separate heater/cooler input_boolean switches.
+
+    Used for regression tests (issue #514) that verify no spurious turn_off calls
+    are sent to idle switches when a single physical device shares both heat and
+    cool control paths.
+
+    Entities created:
+        input_boolean.heater  - heater switch
+        input_boolean.cooler  - cooler switch
+        sensor.test           - temperature sensor (common.ENT_SENSOR)
+
+    Climate config:
+        heat_cool_mode=True, target_temp_low=20, target_temp_high=25
+    """
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(
+        hass,
+        input_boolean.DOMAIN,
+        {"input_boolean": {"heater": None, "cooler": None}},
+    )
+    assert await async_setup_component(
+        hass,
+        input_number.DOMAIN,
+        {
+            "input_number": {
+                "temp": {
+                    "name": "test",
+                    "initial": 10,
+                    "min": 0,
+                    "max": 40,
+                    "step": 1,
+                }
+            }
+        },
+    )
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "cooler": "input_boolean.cooler",
+                "heater": "input_boolean.heater",
+                "heat_cool_mode": True,
+                "target_sensor": common.ENT_SENSOR,
+                "initial_hvac_mode": HVACMode.HEAT_COOL,
+                "target_temp_low": 20,
+                "target_temp_high": 25,
+            }
+        },
+    )
+    await hass.async_block_till_done()
 
 
 def setup_sensor(hass: HomeAssistant, temp: float) -> None:

--- a/tests/test_dual_mode.py
+++ b/tests/test_dual_mode.py
@@ -1,5 +1,6 @@
 """The tests for the dual_smart_thermostat."""
 
+from contextlib import contextmanager
 import datetime
 from datetime import timedelta
 import logging
@@ -25,8 +26,10 @@ from homeassistant.components.climate.const import (
     DOMAIN as CLIMATE,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_TEMPERATURE,
     ENTITY_MATCH_ALL,
+    EVENT_CALL_SERVICE,
     SERVICE_TURN_OFF,
     STATE_CLOSED,
     STATE_OFF,
@@ -65,6 +68,7 @@ from . import (  # noqa: F401
     setup_comp_dual_presets,
     setup_comp_heat_cool_1,
     setup_comp_heat_cool_2,
+    setup_comp_heat_cool_dual_switch,
     setup_comp_heat_cool_fan_config,
     setup_comp_heat_cool_fan_config_2,
     setup_comp_heat_cool_fan_presets,
@@ -3967,3 +3971,128 @@ async def test_heat_cool_mode_opening_timeout(
     # Then
     assert hass.states.get(heater_switch).state == STATE_OFF
     assert hass.states.get(cooler_switch).state == STATE_ON
+
+
+@contextmanager
+def track_turn_off_calls(hass, entity_id):
+    """Context manager tracking homeassistant.turn_off calls for entity_id via the event bus."""
+    calls = []
+
+    def _listener(event):
+        if (
+            event.data.get("domain") == HASS_DOMAIN
+            and event.data.get("service") == SERVICE_TURN_OFF
+            and event.data.get("service_data", {}).get(ATTR_ENTITY_ID) == entity_id
+        ):
+            calls.append(event.data)
+
+    unsub = hass.bus.async_listen(EVENT_CALL_SERVICE, _listener)
+    try:
+        yield calls
+    finally:
+        unsub()
+
+
+@pytest.mark.asyncio
+async def test_heat_cool_mode_does_not_turn_off_idle_cooler_when_heating(
+    hass: HomeAssistant, setup_comp_heat_cool_dual_switch  # noqa: F811
+):
+    """Cooler switch must not receive turn_off when it is already idle.
+
+    Regression test for issue #514: when a single physical AC unit is controlled
+    by two virtual switches (one for heat mode, one for cool mode), an unnecessary
+    turn_off sent to the idle cooler switch causes the physical device to turn off,
+    cancelling the just-activated heating.
+    """
+    heater_switch = "input_boolean.heater"
+    cooler_switch = "input_boolean.cooler"
+
+    assert hass.states.get(heater_switch).state == STATE_OFF
+    assert hass.states.get(cooler_switch).state == STATE_OFF
+
+    with track_turn_off_calls(hass, cooler_switch) as cooler_turn_offs:
+        # Temperature too cold — heater should activate
+        setup_sensor(hass, 18)
+        await hass.async_block_till_done()
+
+        assert hass.states.get(heater_switch).state == STATE_ON
+        assert hass.states.get(cooler_switch).state == STATE_OFF
+
+        # Cooler must NOT have received a turn_off call while it was already idle
+        assert cooler_turn_offs == [], (
+            f"Cooler received {len(cooler_turn_offs)} unexpected turn_off call(s) while idle. "
+            "This causes single-device setups (one AC unit, two virtual switches) to "
+            "turn off when heating is activated."
+        )
+
+
+@pytest.mark.asyncio
+async def test_heat_cool_mode_does_not_turn_off_idle_heater_when_cooling(
+    hass: HomeAssistant, setup_comp_heat_cool_dual_switch  # noqa: F811
+):
+    """Heater switch must not receive turn_off when it is already idle.
+
+    Regression test for issue #514 (cooling side): an unnecessary turn_off sent
+    to the idle heater switch causes the physical device to turn off, cancelling
+    the just-activated cooling.
+    """
+    heater_switch = "input_boolean.heater"
+    cooler_switch = "input_boolean.cooler"
+
+    assert hass.states.get(heater_switch).state == STATE_OFF
+    assert hass.states.get(cooler_switch).state == STATE_OFF
+
+    with track_turn_off_calls(hass, heater_switch) as heater_turn_offs:
+        # Temperature too hot — cooler should activate
+        setup_sensor(hass, 27)
+        await hass.async_block_till_done()
+
+        assert hass.states.get(cooler_switch).state == STATE_ON
+        assert hass.states.get(heater_switch).state == STATE_OFF
+
+        # Heater must NOT have received a turn_off call while it was already idle
+        assert heater_turn_offs == [], (
+            f"Heater received {len(heater_turn_offs)} unexpected turn_off call(s) while idle. "
+            "This causes single-device setups (one AC unit, two virtual switches) to "
+            "turn off when cooling is activated."
+        )
+
+
+@pytest.mark.asyncio
+async def test_heat_cool_mode_does_not_turn_off_either_idle_device_when_temp_in_range(
+    hass: HomeAssistant, setup_comp_heat_cool_dual_switch  # noqa: F811
+):
+    """Neither idle device should receive turn_off when temperature is in comfort range.
+
+    Regression test for issue #514 (else-case): when temp is already within the
+    heat/cool setpoint range and both devices are off, no turn_off commands should
+    be sent to either switch.  An unnecessary turn_off to a virtual switch backed
+    by a shared physical AC unit would turn the device off even when it is idle.
+    """
+    heater_switch = "input_boolean.heater"
+    cooler_switch = "input_boolean.cooler"
+
+    assert hass.states.get(heater_switch).state == STATE_OFF
+    assert hass.states.get(cooler_switch).state == STATE_OFF
+
+    with track_turn_off_calls(
+        hass, heater_switch
+    ) as heater_turn_offs, track_turn_off_calls(
+        hass, cooler_switch
+    ) as cooler_turn_offs:
+        # Temperature in comfort range — no device should activate or receive turn_off
+        setup_sensor(hass, 22)
+        await hass.async_block_till_done()
+
+        assert hass.states.get(heater_switch).state == STATE_OFF
+        assert hass.states.get(cooler_switch).state == STATE_OFF
+
+        # Neither idle device should have received a turn_off call
+        assert heater_turn_offs == [], (
+            f"Heater received {len(heater_turn_offs)} unexpected turn_off call(s) "
+            "while already idle and temperature was in comfort range."
+        )
+        assert cooler_turn_offs == [], (
+            f"Cooler received {len(cooler_turn_offs)} unexpected turn_off call(s) "
+            "while already idle and temperature was in comfort range."
+        )


### PR DESCRIPTION
## Summary

Fixes #514 — AC units turning off unexpectedly after activating heat/cool mode when a single physical device is controlled by two virtual switches.

- Guard `async_turn_off()` calls in `_async_auto_toggle` with `is_active` checks so idle switches never receive phantom turn-off commands
- Simplify the `else` (in-range) branch to reuse the existing `async_turn_off_all(time)` helper
- Add three regression tests covering all three branches of `_async_auto_toggle`

## Root cause

In `HeaterCoolerDevice._async_auto_toggle`, the `too_cold` and `too_hot` branches unconditionally called `async_turn_off()` on the opposite device even when it was already idle. For users with a single physical AC unit mapped to two virtual switches (one for heat, one for cool), this phantom `turn_off` arrived at the physical device immediately after the `turn_on`, causing it to shut back off.

## Test plan

- [ ] `test_heat_cool_mode_does_not_turn_off_idle_cooler_when_heating` — temp below low setpoint, heater activates, cooler receives no `turn_off`
- [ ] `test_heat_cool_mode_does_not_turn_off_idle_heater_when_cooling` — temp above high setpoint, cooler activates, heater receives no `turn_off`
- [ ] `test_heat_cool_mode_does_not_turn_off_either_idle_device_when_temp_in_range` — temp in comfort range, neither device activates or receives `turn_off`
- [ ] Full test suite: 1367 passed, 2 skipped