### PR TITLE
ci: ignore runner-side pip CVE in dependency-audit

### DIFF
--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -98,6 +98,8 @@ jobs:
           # aiohttp 3.11.x CVEs (fixed in 3.13.4):
           # pytest 9.0.0 CVE GHSA-6w46-j5rx-g56g (fixed in 9.0.3):
           # pinned to ==9.0.0 by pytest-homeassistant-custom-component.
+          # pip 26.0.1 CVE GHSA-58qw-9mgm-455v (concatenated tar/ZIP handling):
+          # ships with the GitHub Actions runner; cannot be controlled by us.
           HA_IGNORES="\
             --ignore-vuln GHSA-9548-qrrj-x5pj \
             --ignore-vuln GHSA-6mq8-rvhq-8wgg \
@@ -139,7 +141,8 @@ jobs:
             --ignore-vuln GHSA-hx9q-6w63-j58v \
             --ignore-vuln GHSA-vp96-hxj8-p424 \
             --ignore-vuln GHSA-5pwr-322w-8jr4 \
-            --ignore-vuln GHSA-6w46-j5rx-g56g"
+            --ignore-vuln GHSA-6w46-j5rx-g56g \
+            --ignore-vuln GHSA-58qw-9mgm-455v"
           pip-audit --desc --format=json --output=pip-audit-report.json $HA_IGNORES || true
           pip-audit --desc $HA_IGNORES
         continue-on-error: false


### PR DESCRIPTION
## Summary

- pip 26.0.1 (the package manager shipped with the GitHub Actions runner) has CVE [GHSA-58qw-9mgm-455v](https://github.com/advisories/GHSA-58qw-9mgm-455v) — concatenated tar/ZIP archive handling. It surfaces in pip-audit even though it's not one of our dependencies and we cannot upgrade it from this repo.
- The dependency-audit check has been failing on every PR (and dependabot run) since 2026-04-28 20:27 UTC because of this. Other PRs affected: PR #577 and the dependabot pip update PRs.
- Add the GHSA to the existing \`HA_IGNORES\` block in \`security-check.yml\` with a brief comment explaining the source. Same pattern used for the existing aiohttp / pytest pins.

## Test plan

- [ ] dependency-audit job passes on this PR
- [ ] After merge, rebase PR #577 and confirm its dependency-audit also passes