### PR TITLE
fix: expose FAN_ONLY mode with heat_pump and heater configurations (#585)

### DIFF
--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -99,8 +99,10 @@ jobs:
           # pytest 9.0.0 CVE GHSA-6w46-j5rx-g56g (fixed in 9.0.3):
           # pinned to ==9.0.0 by pytest-homeassistant-custom-component.
           # pip 26.0.1 CVE GHSA-58qw-9mgm-455v (concatenated tar/ZIP handling):
+          # pip 26.0.1 CVE GHSA-jp4c-xjxw-mgf9 (self-update timing, fixed in 26.1):
           # ships with the GitHub Actions runner; cannot be controlled by us.
           HA_IGNORES="\
+            --ignore-vuln GHSA-jp4c-xjxw-mgf9 \
             --ignore-vuln GHSA-9548-qrrj-x5pj \
             --ignore-vuln GHSA-6mq8-rvhq-8wgg \
             --ignore-vuln GHSA-69f9-5gxw-wvc2 \

--- a/custom_components/dual_smart_thermostat/hvac_device/hvac_device_factory.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/hvac_device_factory.py
@@ -229,30 +229,36 @@ class HVACDeviceFactory:
                 return heater_cooler_device
 
         if heater_device:
+            sub_devices = [heater_device]
+            if fan_device:
+                sub_devices.append(fan_device)
             if dryer_device:
+                sub_devices.append(dryer_device)
+            if len(sub_devices) > 1:
                 return MultiHvacDevice(
                     self.hass,
-                    [heater_device, dryer_device],
+                    sub_devices,
                     self._initial_hvac_mode,
                     environment,
                     openings,
                     self._features,
                 )
-            else:
-                return heater_device
+            return heater_device
 
         if cooler_device:
+            sub_devices = [cooler_device]
             if dryer_device:
+                sub_devices.append(dryer_device)
+            if len(sub_devices) > 1:
                 return MultiHvacDevice(
                     self.hass,
-                    [cooler_device, dryer_device],
+                    sub_devices,
                     self._initial_hvac_mode,
                     environment,
                     openings,
                     self._features,
                 )
-            else:
-                return cooler_device
+            return cooler_device
 
         if fan_device:
             return fan_device

--- a/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
@@ -2,7 +2,7 @@ import logging
 from typing import Callable
 
 from homeassistant.components.climate import HVACAction, HVACMode
-from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.core import Context, HomeAssistant, State, callback
 
 from ..hvac_action_reason.hvac_action_reason import HVACActionReason
 from ..hvac_device.controllable_hvac_device import ControlableHVACDevice
@@ -45,6 +45,18 @@ class MultiHvacDevice(HVACDevice, ControlableHVACDevice):
     def set_context(self, context: Context):
         for device in self.hvac_devices:
             device.set_context(context)
+
+    @callback
+    def on_entity_state_changed(self, entity_id: str, new_state: State) -> None:
+        """Forward state-change notifications to every sub-device.
+
+        Sub-devices (e.g. HeatPumpDevice) may need entity state changes to
+        update their own ``hvac_modes``. After delegating, re-merge the
+        combined mode list so the climate entity sees the latest set.
+        """
+        for device in self.hvac_devices:
+            device.on_entity_state_changed(entity_id, new_state)
+        self.init_hvac_modes(self.hvac_devices)
 
     def get_device_ids(self) -> list[str]:
         device_ids = []

--- a/tests/test_heat_pump_mode.py
+++ b/tests/test_heat_pump_mode.py
@@ -221,6 +221,115 @@ async def test_get_hvac_modes(
     assert set(modes) == set(hvac_modes)
 
 
+@pytest.mark.parametrize(
+    ("cooling_mode", "expected_modes"),
+    [
+        (
+            STATE_ON,
+            [HVACMode.COOL, HVACMode.FAN_ONLY, HVACMode.OFF, HVACMode.AUTO],
+        ),
+        (
+            STATE_OFF,
+            [HVACMode.HEAT, HVACMode.FAN_ONLY, HVACMode.OFF, HVACMode.AUTO],
+        ),
+    ],
+)
+async def test_heat_pump_with_fan_exposes_fan_only_mode(
+    hass: HomeAssistant,
+    setup_comp_1,  # noqa: F811
+    cooling_mode,
+    expected_modes,
+) -> None:
+    """Heat pump configurations with a fan entity must expose FAN_ONLY.
+
+    Regression test for issue #585: when heat_pump_cooling and a fan entity
+    are configured together, the FAN_ONLY mode was silently dropped because
+    the factory only attached fan_device when a cooler_device existed.
+    """
+    heat_pump_cooling_switch = "input_boolean.test2"
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": common.ENT_SWITCH,
+                "fan": common.ENT_FAN,
+                "heat_pump_cooling": heat_pump_cooling_switch,
+                "target_sensor": common.ENT_SENSOR,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("input_boolean.test2", cooling_mode)
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get(common.ENTITY)
+    modes = state.attributes.get("hvac_modes")
+    _LOGGER.debug("Modes: %s", modes)
+    assert set(modes) == set(expected_modes)
+
+
+async def test_heat_pump_with_fan_fan_only_mode_runs_fan_only(
+    hass: HomeAssistant, setup_comp_1  # noqa: F811
+) -> None:
+    """Switching to FAN_ONLY in a heat-pump+fan setup turns the fan on
+    without engaging the heat-pump valve.
+
+    Regression test for issue #585.
+    """
+    from . import setup_switch_dual
+
+    heat_pump_cooling_switch = "input_boolean.test2"
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": common.ENT_SWITCH,
+                "fan": common.ENT_FAN,
+                "heat_pump_cooling": heat_pump_cooling_switch,
+                "target_sensor": common.ENT_SENSOR,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("input_boolean.test2", STATE_OFF)
+    await hass.async_block_till_done()
+
+    setup_sensor(hass, 28)
+    await common.async_set_temperature(hass, 20)
+    await hass.async_block_till_done()
+
+    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
+
+    await common.async_set_hvac_mode(hass, HVACMode.FAN_ONLY)
+    await hass.async_block_till_done()
+
+    fan_on = [
+        c
+        for c in calls
+        if c.service == SERVICE_TURN_ON and c.data.get("entity_id") == common.ENT_FAN
+    ]
+    heat_pump_on = [
+        c
+        for c in calls
+        if c.service == SERVICE_TURN_ON and c.data.get("entity_id") == common.ENT_SWITCH
+    ]
+    assert len(fan_on) == 1, f"expected fan switch turned on, got: {calls}"
+    assert (
+        len(heat_pump_on) == 0
+    ), f"heat-pump switch must not be turned on in FAN_ONLY mode, got: {calls}"
+
+
 @pytest.fixture
 async def setup_comp_heat_pump_presets(hass: HomeAssistant) -> None:
     """Initialize components."""


### PR DESCRIPTION
## Summary
- Fixes #585: when `heat_pump_cooling` (or just `heater`, no cooler) was paired with a `fan` entity, `FAN_ONLY` never appeared in the climate's `hvac_modes`. The factory created the `fan_device` but only ever attached it to the device chain via `CoolerFanDevice` — outside that path it was silently dropped.
- Compose `fan_device` into a `MultiHvacDevice` together with the heater/heat-pump device (and optional dryer) when no cooler exists.
- Forward `on_entity_state_changed` through `MultiHvacDevice` so the wrapped `HeatPumpDevice` keeps swapping HEAT/COOL based on the `heat_pump_cooling` flag, and re-merge `hvac_modes` afterwards.

## Test plan
- [x] New regression test `test_heat_pump_with_fan_exposes_fan_only_mode` — parametrized over `heat_pump_cooling` ON/OFF, asserts `FAN_ONLY` is in the exposed `hvac_modes` alongside HEAT or COOL.
- [x] New behavioral test `test_heat_pump_with_fan_fan_only_mode_runs_fan_only` — selecting `FAN_ONLY` turns the fan switch on without engaging the heat-pump valve.
- [x] Full suite: **1515 passed, 2 skipped** (`./scripts/docker-test`).
- [x] Lint clean on changed files (isort / black / flake8 / ruff). Pre-existing codespell warnings are unrelated.