### PR TITLE
fix: prevent keep_alive from turning devices on while thermostat is OFF (#587)

### DIFF
--- a/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
@@ -200,6 +200,19 @@ class GenericHVACDevice(
             any_opening_open,
         )
 
+        # When the climate is OFF, keep-alive bypasses `needs_control` so it can
+        # enforce the device staying off. We must never run goal-based logic
+        # here — only turn the switch off if it ended up on externally.
+        # See issue #587.
+        if self._hvac_mode == HVACMode.OFF:
+            if self.hvac_controller.is_active:
+                _LOGGER.info(
+                    "Climate mode is OFF but %s is on; turning it off",
+                    self.entity_id,
+                )
+                await self.async_turn_off()
+            return
+
         if self.hvac_controller.is_active:
             await self.hvac_controller.async_control_device_when_on(
                 self.strategy,

--- a/tests/edge_cases/test_issue_587_off_keep_alive_turns_on.py
+++ b/tests/edge_cases/test_issue_587_off_keep_alive_turns_on.py
@@ -1,0 +1,121 @@
+"""Regression test for issue #587.
+
+When the thermostat is in HVACMode.OFF and ``keep_alive`` is configured,
+the keep-alive timer used to call into the controller and trigger the
+goal-based ``turn_on`` branch in ``generic_controller`` — even though
+the climate is supposed to be off. This caused heaters/coolers to
+switch on by themselves whenever the temperature happened to be away
+from target.
+
+Issue: https://github.com/swingerman/ha-dual-smart-thermostat/issues/587
+"""
+
+import datetime
+
+from homeassistant.components.climate import HVACMode
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+import pytest
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.dual_smart_thermostat.const import DOMAIN
+
+from .. import common, setup_sensor, setup_switch
+
+
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_off_mode_keep_alive_does_not_turn_heater_on(
+    hass: HomeAssistant,
+) -> None:
+    """Keep-alive timer must not turn the heater on while thermostat is OFF.
+
+    Reproduces the symptom reported in #587: thermostat shows OFF but the
+    heater entity gets switched on after every keep_alive interval because
+    the controller's "turn on because goal not reached" path lacks an
+    HVACMode.OFF guard.
+    """
+    heater_switch = common.ENT_SWITCH
+    assert await async_setup_component(
+        hass,
+        "climate",
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test_thermostat",
+                "heater": heater_switch,
+                "target_sensor": common.ENT_SENSOR,
+                "cold_tolerance": 0.3,
+                "hot_tolerance": 0.1,
+                "target_temp": 22.0,
+                "keep_alive": datetime.timedelta(minutes=3),
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Heater switch off, current temperature well below target (heating goal
+    # not reached). Thermostat itself is OFF.
+    calls = setup_switch(hass, False)
+    setup_sensor(hass, 18.0)
+    await common.async_set_hvac_mode(hass, HVACMode.OFF)
+    await hass.async_block_till_done()
+    calls.clear()
+
+    now = dt_util.utcnow()
+    for i in range(1, 4):
+        async_fire_time_changed(hass, now + datetime.timedelta(minutes=3 * i))
+        await hass.async_block_till_done()
+
+    turn_on_calls = [c for c in calls if c.service == "turn_on"]
+    assert turn_on_calls == [], (
+        f"Heater must not be turned on by keep-alive while thermostat is OFF, "
+        f"but got {len(turn_on_calls)} turn_on call(s): {turn_on_calls}"
+    )
+
+
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_off_mode_keep_alive_turns_externally_on_heater_off(
+    hass: HomeAssistant,
+) -> None:
+    """Keep-alive should still enforce OFF: if the switch is externally on
+    while the thermostat is OFF, keep-alive must turn it off.
+
+    This guards the intended behaviour that the OFF-bypass in
+    ``needs_control`` was designed to preserve.
+    """
+    heater_switch = common.ENT_SWITCH
+    assert await async_setup_component(
+        hass,
+        "climate",
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test_thermostat",
+                "heater": heater_switch,
+                "target_sensor": common.ENT_SENSOR,
+                "cold_tolerance": 0.3,
+                "hot_tolerance": 0.1,
+                "target_temp": 22.0,
+                "keep_alive": datetime.timedelta(minutes=3),
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Heater switch externally ON, thermostat OFF.
+    calls = setup_switch(hass, True)
+    setup_sensor(hass, 18.0)
+    await common.async_set_hvac_mode(hass, HVACMode.OFF)
+    await hass.async_block_till_done()
+    calls.clear()
+
+    now = dt_util.utcnow()
+    async_fire_time_changed(hass, now + datetime.timedelta(minutes=3))
+    await hass.async_block_till_done()
+
+    turn_off_calls = [c for c in calls if c.service == "turn_off"]
+    assert len(turn_off_calls) >= 1, (
+        "Keep-alive should turn the externally-on heater off while thermostat "
+        f"is OFF, but got {turn_off_calls}"
+    )


### PR DESCRIPTION
Fixes #587.

## Summary
- When `keep_alive` was configured, the keep-alive ticks would turn the heater/cooler switch on by themselves any time the temperature happened to be away from target — even though the thermostat was in `HVACMode.OFF`. The user confirmed in [#587](https://github.com/swingerman/ha-dual-smart-thermostat/issues/587) that this matched their symptom and that disabling `keep_alive` works around it.
- Root cause: `generic_controller.needs_control` deliberately lets keep-alive past the OFF check so the controller can re-assert OFF on externally-toggled switches, but `async_control_device_when_off`'s first branch (`turn on because goal not reached`) has no `hvac_mode` guard. Every keep-alive tick triggered that branch.
- Fix in `generic_hvac_device.async_control_hvac`: when `hvac_mode == HVACMode.OFF`, only the enforce-OFF path runs — turn the switch off if it's externally on, otherwise do nothing. The goal-based control paths are reserved for non-OFF modes.

## Test plan
- [x] New regression test `tests/edge_cases/test_issue_587_off_keep_alive_turns_on.py` with two cases:
  - thermostat OFF + heater externally off + temp far from target: keep-alive must **not** turn it on.
  - thermostat OFF + heater externally on: keep-alive must turn it off (the original OFF-enforcement still works).
  Both fail on master and pass with this change.
- [x] Full suite: **1517 passed, 2 skipped** (`./scripts/docker-test`).
- [x] Lint clean on the changed files (isort / black / flake8 / ruff).