### PR TITLE
fix: prevent duplicate hvac_action_reason sensor registration for UI config entries (#584)

### DIFF
--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -314,8 +314,22 @@ async def async_setup_platform(
     """Set up the smart dual thermostat platform."""
 
     await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
-    await _async_setup_config(
+    sensor_key = await _async_setup_config(
         hass, config, config.get(CONF_UNIQUE_ID), async_add_entities
+    )
+
+    # UI config entries register the companion sensor via
+    # ``async_forward_entry_setups`` in ``__init__.py``; discovery must run
+    # only for YAML (issue #584 — duplicate registration orphaned the
+    # registry row).
+    hass.async_create_task(
+        discovery.async_load_platform(
+            hass,
+            Platform.SENSOR,
+            DOMAIN,
+            {"name": config[CONF_NAME], "sensor_key": sensor_key},
+            config,
+        )
     )
 
 
@@ -396,8 +410,8 @@ async def _async_setup_config(
     config: dict[str, Any],
     unique_id: str | None,
     async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up the smart dual thermostat platform."""
+) -> str:
+    """Set up the smart dual thermostat platform. Returns the sensor_key."""
 
     # Normalize config values from config flow (strings to proper types)
     # This ensures consistency between YAML config and config entry setup
@@ -478,16 +492,6 @@ async def _async_setup_config(
     thermostat._action_reason_sensor_key = sensor_key
     async_add_entities([thermostat])
 
-    hass.async_create_task(
-        discovery.async_load_platform(
-            hass,
-            Platform.SENSOR,
-            DOMAIN,
-            {"name": name, "sensor_key": sensor_key},
-            config,
-        )
-    )
-
     # Service to set HVACActionReason.
     def set_hvac_action_reason_service(call: ServiceCall) -> None:
         """My first service."""
@@ -515,6 +519,8 @@ async def _async_setup_config(
     hass.services.async_register(
         DOMAIN, SERVICE_SET_HVAC_ACTION_REASON, set_hvac_action_reason_service
     )
+
+    return sensor_key
 
 
 class DualSmartThermostat(ClimateEntity, RestoreEntity):

--- a/tests/edge_cases/test_issue_584_duplicate_hvac_action_reason_sensor.py
+++ b/tests/edge_cases/test_issue_584_duplicate_hvac_action_reason_sensor.py
@@ -1,0 +1,53 @@
+"""Regression test for issue #584.
+
+UI config entries forward setup to the sensor platform via
+``async_forward_entry_setups`` in ``__init__.py``. If ``climate.py`` also
+schedules a discovery load of the same sensor platform, the
+``hvac_action_reason`` sensor gets registered twice with the same unique_id,
+and the rejected duplicate ends up in the entity registry orphaned from its
+config entry (no device, no area, "Delete" greyed out).
+"""
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dual_smart_thermostat.const import (
+    CONF_COLD_TOLERANCE,
+    CONF_HEATER,
+    CONF_HOT_TOLERANCE,
+    CONF_SENSOR,
+    DOMAIN,
+)
+from tests import common, setup_sensor, setup_switch
+
+
+async def test_ui_config_entry_registers_hvac_action_reason_sensor_once(
+    hass: HomeAssistant,
+):
+    """UI config entry registers exactly one hvac_action_reason sensor,
+    linked to its config entry (not orphaned).
+    """
+    setup_sensor(hass, 22.5)
+    setup_switch(hass, False, common.ENT_HEATER)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "test",
+            CONF_HEATER: common.ENT_HEATER,
+            CONF_SENSOR: common.ENT_SENSOR,
+            CONF_COLD_TOLERANCE: 0.3,
+            CONF_HOT_TOLERANCE: 0.3,
+        },
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{config_entry.entry_id}_hvac_action_reason"
+    )
+    assert entity_id is not None
+    assert registry.async_get(entity_id).config_entry_id == config_entry.entry_id


### PR DESCRIPTION
## Summary

Fixes #584.

- `_async_setup_config` was scheduling `discovery.async_load_platform(..., Platform.SENSOR, ...)` for every climate, but for UI config entries `__init__.py` already forwards setup to the sensor platform via `async_forward_entry_setups`. The result was duplicate registration of `HvacActionReasonSensor` with an identical unique_id, a "Platform … does not generate unique IDs" error on every startup, and the surviving entity registry row left orphaned (no `config_entry_id`, no `device_id`, "Delete" greyed out).
- Moved the discovery call into `async_setup_platform` (YAML path only). `_async_setup_config` now returns the computed `sensor_key` so the caller doesn't recompute `unique_id or name`.
- Added a regression test that reproduces the exact failure mode without the fix.

## Test plan

- [x] `./scripts/docker-test tests/edge_cases/test_issue_584_duplicate_hvac_action_reason_sensor.py` passes
- [x] Existing `tests/test_hvac_action_reason_sensor.py` (10 tests) still passes — covers YAML companion sensor creation
- [x] `tests/edge_cases/test_issue_468_*` and `test_issue_499_*` still pass — cover the UI/YAML setup paths
- [x] Verified the regression test fails without the fix (HA logs the exact "ID … already exists" error from the bug report)
- [x] `./scripts/docker-lint` clean