### PR TITLE
Guard preset placeholder temperatures

### DIFF
--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -472,29 +472,27 @@ class EnvironmentManager(StateManager):
     def normalize_preset_temperature(
         self, value: float | None, field_name: str
     ) -> float | None:
-        """Return preset temperature only if it fits thermostat bounds."""
+        """Return preset temperature unless it is a non-physical placeholder.
+
+        Some real-world configs use ``temperature: 0`` (or negative values) as a
+        placeholder meaning "unset" inside a preset definition. Applying those
+        would overwrite a valid target with a bogus value, so we treat anything
+        at or below zero as unset and ignore it.
+
+        Note: we deliberately do NOT clamp against ``min_temp``/``max_temp`` here.
+        Legitimate low presets such as ``PRESET_ANTI_FREEZE`` (5°C) sit below the
+        default ``min_temp`` of 7°C and must still be honored.
+        """
         if value is None:
             return None
 
         temp = float(value)
-        min_temp = self.min_temp
-        max_temp = self.max_temp
 
-        if min_temp is not None and temp < min_temp:
+        if temp <= 0:
             _LOGGER.warning(
-                "Ignoring preset %s=%s because it is below min_temp=%s",
+                "Ignoring preset %s=%s because it is a placeholder (<= 0)",
                 field_name,
                 temp,
-                min_temp,
-            )
-            return None
-
-        if max_temp is not None and temp > max_temp:
-            _LOGGER.warning(
-                "Ignoring preset %s=%s because it is above max_temp=%s",
-                field_name,
-                temp,
-                max_temp,
             )
             return None
 
@@ -920,21 +918,25 @@ class EnvironmentManager(StateManager):
             preset_temp_low = self.get_validated_preset_temp_low(preset_env)
             preset_temp_high = self.get_validated_preset_temp_high(preset_env)
 
-            if preset_temp_low is not None:
-                self.target_temp_low = preset_temp_low
-            if preset_temp_high is not None:
-                self.target_temp_high = preset_temp_high
-            elif preset_env.has_temp():
+            if preset_temp_low is not None or preset_temp_high is not None:
+                if preset_temp_low is not None:
+                    self.target_temp_low = preset_temp_low
+                if preset_temp_high is not None:
+                    self.target_temp_high = preset_temp_high
+            else:
                 # Single-temp preset applied while in range (heat/cool) mode.
                 # Without this fallback the preset is silently ignored and
                 # switching presets appears to do nothing (issue #592). Apply
-                # the single value to both setpoints so the change is honored.
-                _LOGGER.debug(
-                    "Applying single-temp preset %s to both setpoints in range mode",
-                    preset_temp,
-                )
-                self.target_temp_low = preset_temp
-                self.target_temp_high = preset_temp
+                # the single (bounds-validated) value to both setpoints so the
+                # change is honored.
+                preset_temp = self.get_validated_preset_temperature(preset_env)
+                if preset_temp is not None:
+                    _LOGGER.debug(
+                        "Applying single-temp preset %s to both setpoints in range mode",
+                        preset_temp,
+                    )
+                    self.target_temp_low = preset_temp
+                    self.target_temp_high = preset_temp
 
         else:
             _LOGGER.debug(
@@ -943,8 +945,6 @@ class EnvironmentManager(StateManager):
             )
 
             preset_temp = self.get_validated_preset_temperature(preset_env)
-            preset_temp_low = self.get_validated_preset_temp_low(preset_env)
-            preset_temp_high = self.get_validated_preset_temp_high(preset_env)
 
             if preset_temp is not None:
                 _LOGGER.debug(
@@ -952,6 +952,11 @@ class EnvironmentManager(StateManager):
                 )
                 self.target_temp = preset_temp
                 return
+
+            # Only needed past the single-temp early return; the getters may
+            # evaluate templates, so don't pay for them on the common path.
+            preset_temp_low = self.get_validated_preset_temp_low(preset_env)
+            preset_temp_high = self.get_validated_preset_temp_high(preset_env)
 
             if preset_temp_low is None and preset_temp_high is None:
                 _LOGGER.debug(

--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -469,53 +469,6 @@ class EnvironmentManager(StateManager):
         self._target_temp = temperature
         # self._saved_target_temp = temperature
 
-    def normalize_preset_temperature(
-        self, value: float | None, field_name: str
-    ) -> float | None:
-        """Return preset temperature unless it is a non-physical placeholder.
-
-        Some real-world configs use ``temperature: 0`` (or negative values) as a
-        placeholder meaning "unset" inside a preset definition. Applying those
-        would overwrite a valid target with a bogus value, so we treat anything
-        at or below zero as unset and ignore it.
-
-        Note: we deliberately do NOT clamp against ``min_temp``/``max_temp`` here.
-        Legitimate low presets such as ``PRESET_ANTI_FREEZE`` (5°C) sit below the
-        default ``min_temp`` of 7°C and must still be honored.
-        """
-        if value is None:
-            return None
-
-        temp = float(value)
-
-        if temp <= 0:
-            _LOGGER.warning(
-                "Ignoring preset %s=%s because it is a placeholder (<= 0)",
-                field_name,
-                temp,
-            )
-            return None
-
-        return temp
-
-    def get_validated_preset_temperature(self, preset_env: PresetEnv) -> float | None:
-        """Resolve and validate the preset target temperature."""
-        return self.normalize_preset_temperature(
-            preset_env.get_temperature(self.hass), ATTR_TEMPERATURE
-        )
-
-    def get_validated_preset_temp_low(self, preset_env: PresetEnv) -> float | None:
-        """Resolve and validate the preset low temperature."""
-        return self.normalize_preset_temperature(
-            preset_env.get_target_temp_low(self.hass), ATTR_TARGET_TEMP_LOW
-        )
-
-    def get_validated_preset_temp_high(self, preset_env: PresetEnv) -> float | None:
-        """Resolve and validate the preset high temperature."""
-        return self.normalize_preset_temperature(
-            preset_env.get_target_temp_high(self.hass), ATTR_TARGET_TEMP_HIGH
-        )
-
     def set_temperature_range(
         self, temperature: float, temp_low: float, temp_high: float
     ) -> None:
@@ -915,8 +868,9 @@ class EnvironmentManager(StateManager):
                 preset_env.to_dict,
             )
 
-            preset_temp_low = self.get_validated_preset_temp_low(preset_env)
-            preset_temp_high = self.get_validated_preset_temp_high(preset_env)
+            # Getters evaluate templates and filter placeholder values (<= 0).
+            preset_temp_low = preset_env.get_target_temp_low(self.hass)
+            preset_temp_high = preset_env.get_target_temp_high(self.hass)
 
             if preset_temp_low is not None or preset_temp_high is not None:
                 if preset_temp_low is not None:
@@ -927,9 +881,8 @@ class EnvironmentManager(StateManager):
                 # Single-temp preset applied while in range (heat/cool) mode.
                 # Without this fallback the preset is silently ignored and
                 # switching presets appears to do nothing (issue #592). Apply
-                # the single (bounds-validated) value to both setpoints so the
-                # change is honored.
-                preset_temp = self.get_validated_preset_temperature(preset_env)
+                # the single value to both setpoints so the change is honored.
+                preset_temp = preset_env.get_temperature(self.hass)
                 if preset_temp is not None:
                     _LOGGER.debug(
                         "Applying single-temp preset %s to both setpoints in range mode",
@@ -944,7 +897,7 @@ class EnvironmentManager(StateManager):
                 preset_env.to_dict,
             )
 
-            preset_temp = self.get_validated_preset_temperature(preset_env)
+            preset_temp = preset_env.get_temperature(self.hass)
 
             if preset_temp is not None:
                 _LOGGER.debug(
@@ -955,8 +908,8 @@ class EnvironmentManager(StateManager):
 
             # Only needed past the single-temp early return; the getters may
             # evaluate templates, so don't pay for them on the common path.
-            preset_temp_low = self.get_validated_preset_temp_low(preset_env)
-            preset_temp_high = self.get_validated_preset_temp_high(preset_env)
+            preset_temp_low = preset_env.get_target_temp_low(self.hass)
+            preset_temp_high = preset_env.get_target_temp_high(self.hass)
 
             if preset_temp_low is None and preset_temp_high is None:
                 _LOGGER.debug(

--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -469,6 +469,55 @@ class EnvironmentManager(StateManager):
         self._target_temp = temperature
         # self._saved_target_temp = temperature
 
+    def normalize_preset_temperature(
+        self, value: float | None, field_name: str
+    ) -> float | None:
+        """Return preset temperature only if it fits thermostat bounds."""
+        if value is None:
+            return None
+
+        temp = float(value)
+        min_temp = self.min_temp
+        max_temp = self.max_temp
+
+        if min_temp is not None and temp < min_temp:
+            _LOGGER.warning(
+                "Ignoring preset %s=%s because it is below min_temp=%s",
+                field_name,
+                temp,
+                min_temp,
+            )
+            return None
+
+        if max_temp is not None and temp > max_temp:
+            _LOGGER.warning(
+                "Ignoring preset %s=%s because it is above max_temp=%s",
+                field_name,
+                temp,
+                max_temp,
+            )
+            return None
+
+        return temp
+
+    def get_validated_preset_temperature(self, preset_env: PresetEnv) -> float | None:
+        """Resolve and validate the preset target temperature."""
+        return self.normalize_preset_temperature(
+            preset_env.get_temperature(self.hass), ATTR_TEMPERATURE
+        )
+
+    def get_validated_preset_temp_low(self, preset_env: PresetEnv) -> float | None:
+        """Resolve and validate the preset low temperature."""
+        return self.normalize_preset_temperature(
+            preset_env.get_target_temp_low(self.hass), ATTR_TARGET_TEMP_LOW
+        )
+
+    def get_validated_preset_temp_high(self, preset_env: PresetEnv) -> float | None:
+        """Resolve and validate the preset high temperature."""
+        return self.normalize_preset_temperature(
+            preset_env.get_target_temp_high(self.hass), ATTR_TARGET_TEMP_HIGH
+        )
+
     def set_temperature_range(
         self, temperature: float, temp_low: float, temp_high: float
     ) -> None:
@@ -862,19 +911,18 @@ class EnvironmentManager(StateManager):
             is_range_mode,
         )
 
-        # Use template-aware getters to evaluate templates (#538)
-        preset_temp = preset_env.get_temperature(self.hass)
-        preset_temp_low = preset_env.get_target_temp_low(self.hass)
-        preset_temp_high = preset_env.get_target_temp_high(self.hass)
-
         if is_range_mode:
             _LOGGER.debug(
                 "Setting temperatures from preset range mode, preset_env: %s",
                 preset_env.to_dict,
             )
 
-            if preset_env.has_temp_range():
+            preset_temp_low = self.get_validated_preset_temp_low(preset_env)
+            preset_temp_high = self.get_validated_preset_temp_high(preset_env)
+
+            if preset_temp_low is not None:
                 self.target_temp_low = preset_temp_low
+            if preset_temp_high is not None:
                 self.target_temp_high = preset_temp_high
             elif preset_env.has_temp():
                 # Single-temp preset applied while in range (heat/cool) mode.
@@ -894,32 +942,18 @@ class EnvironmentManager(StateManager):
                 preset_env.to_dict,
             )
 
-            if preset_env.has_temp():
+            preset_temp = self.get_validated_preset_temperature(preset_env)
+            preset_temp_low = self.get_validated_preset_temp_low(preset_env)
+            preset_temp_high = self.get_validated_preset_temp_high(preset_env)
+
+            if preset_temp is not None:
                 _LOGGER.debug(
                     "Setting temperatures from preset target mode if target_temp set"
                 )
-
-                # we prioritize the target temp from preset if it is set
-                if preset_env.has_temp():
-                    self.target_temp = preset_temp
-                # only after that we check if the temp range is set
-                elif preset_env.has_temp_range():
-                    if hvac_mode == HVACMode.HEAT:
-                        _LOGGER.debug(
-                            "Setting temperatures from preset target mode if HVACMode.HEAT. Preset: %s",
-                            preset_temp_low,
-                        )
-                        self.target_temp = preset_temp_low
-                    elif hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY]:
-                        _LOGGER.debug(
-                            "Setting temperatures from preset target mode if HVACMode.COOL, HVACMode.FAN_ONLY. Preset: %s",
-                            preset_temp_high,
-                        )
-                        self.target_temp = preset_temp_high
-
+                self.target_temp = preset_temp
                 return
 
-            if not preset_env.has_temp_range():
+            if preset_temp_low is None and preset_temp_high is None:
                 _LOGGER.debug(
                     "Setting temperatures from preset target mode when preset not in presets_range. Saved temp: %s",
                     self._saved_target_temp,
@@ -934,12 +968,15 @@ class EnvironmentManager(StateManager):
                 )
 
                 if hvac_mode == HVACMode.HEAT:
-                    _LOGGER.debug(
-                        "Setting temperatures from preset range mode if HVACMode.HEAT. Preset: %s",
-                        preset_temp_low,
-                    )
-                    self._target_temp = preset_temp_low
-                elif hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY]:
+                    if preset_temp_low is not None:
+                        _LOGGER.debug(
+                            "Setting temperatures from preset range mode if HVACMode.HEAT. Preset: %s",
+                            preset_temp_low,
+                        )
+                        self._target_temp = preset_temp_low
+                elif hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY] and (
+                    preset_temp_high is not None
+                ):
                     _LOGGER.debug(
                         "Setting temperatures from preset range mode if HVACMode.COOL, HVACMode.FAN_ONLY. Preset: %s, sved_target_temp: %s",
                         preset_temp_high,

--- a/custom_components/dual_smart_thermostat/managers/preset_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/preset_manager.py
@@ -236,8 +236,8 @@ class PresetManager(StateManager):
     ):
         """Restore range temperatures from preset, preferring old state values."""
         # Use template-aware getters for preset temperatures
-        preset_temp_low = preset.get_target_temp_low(self.hass)
-        preset_temp_high = preset.get_target_temp_high(self.hass)
+        preset_temp_low = self._environment.get_validated_preset_temp_low(preset)
+        preset_temp_high = self._environment.get_validated_preset_temp_high(preset)
 
         # Prefer old state values, fall back to preset values
         if preset_temp_low is not None:
@@ -258,17 +258,25 @@ class PresetManager(StateManager):
         """Restore temperature from preset configuration (supports multiple formats)."""
         # Handle legacy float format
         if isinstance(preset, float):
-            self._environment.target_temp = float(preset)
+            temp = self._environment.normalize_preset_temperature(
+                float(preset), ATTR_TEMPERATURE
+            )
+            if temp is not None:
+                self._environment.target_temp = temp
             return
 
         # Handle legacy dict format
         if isinstance(preset, dict) and ATTR_TEMPERATURE in preset:
-            self._environment.target_temp = float(preset[ATTR_TEMPERATURE])
+            temp = self._environment.normalize_preset_temperature(
+                float(preset[ATTR_TEMPERATURE]), ATTR_TEMPERATURE
+            )
+            if temp is not None:
+                self._environment.target_temp = temp
             return
 
         # Handle PresetEnv object with template support
         if hasattr(preset, "get_temperature"):
-            temp = preset.get_temperature(self.hass)
+            temp = self._environment.get_validated_preset_temperature(preset)
             if temp is not None:
                 self._environment.target_temp = temp
             return

--- a/custom_components/dual_smart_thermostat/managers/preset_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/preset_manager.py
@@ -14,7 +14,7 @@ from ..const import CONF_PRESETS, CONF_PRESETS_OLD
 from ..managers.environment_manager import EnvironmentManager
 from ..managers.feature_manager import FeatureManager
 from ..managers.state_manager import StateManager
-from ..preset_env.preset_env import PresetEnv
+from ..preset_env.preset_env import PresetEnv, normalize_preset_temperature
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -235,9 +235,9 @@ class PresetManager(StateManager):
         old_target_temp_high: float | None,
     ):
         """Restore range temperatures from preset, preferring old state values."""
-        # Use template-aware getters for preset temperatures
-        preset_temp_low = self._environment.get_validated_preset_temp_low(preset)
-        preset_temp_high = self._environment.get_validated_preset_temp_high(preset)
+        # Template-aware getters; placeholder values (<= 0) come back as None
+        preset_temp_low = preset.get_target_temp_low(self.hass)
+        preset_temp_high = preset.get_target_temp_high(self.hass)
 
         # Prefer old state values, fall back to preset values
         if preset_temp_low is not None:
@@ -258,16 +258,14 @@ class PresetManager(StateManager):
         """Restore temperature from preset configuration (supports multiple formats)."""
         # Handle legacy float format
         if isinstance(preset, float):
-            temp = self._environment.normalize_preset_temperature(
-                float(preset), ATTR_TEMPERATURE
-            )
+            temp = normalize_preset_temperature(float(preset), ATTR_TEMPERATURE)
             if temp is not None:
                 self._environment.target_temp = temp
             return
 
         # Handle legacy dict format
         if isinstance(preset, dict) and ATTR_TEMPERATURE in preset:
-            temp = self._environment.normalize_preset_temperature(
+            temp = normalize_preset_temperature(
                 float(preset[ATTR_TEMPERATURE]), ATTR_TEMPERATURE
             )
             if temp is not None:
@@ -276,7 +274,7 @@ class PresetManager(StateManager):
 
         # Handle PresetEnv object with template support
         if hasattr(preset, "get_temperature"):
-            temp = self._environment.get_validated_preset_temperature(preset)
+            temp = preset.get_temperature(self.hass)
             if temp is not None:
                 self._environment.target_temp = temp
             return

--- a/custom_components/dual_smart_thermostat/preset_env/preset_env.py
+++ b/custom_components/dual_smart_thermostat/preset_env/preset_env.py
@@ -16,6 +16,36 @@ from ..const import CONF_MAX_FLOOR_TEMP, CONF_MIN_FLOOR_TEMP
 _LOGGER = logging.getLogger(__name__)
 
 
+def normalize_preset_temperature(value: float | None, field_name: str) -> float | None:
+    """Return preset temperature unless it is a non-physical placeholder.
+
+    Some real-world configs use ``temperature: 0`` (or negative values) as a
+    placeholder meaning "unset" inside a preset definition. Applying those
+    would overwrite a valid target with a bogus value, so we treat anything
+    at or below zero as unset and ignore it. Templates can also render such
+    values at apply time, which is why this runs on every read rather than
+    once at parse time.
+
+    Note: we deliberately do NOT clamp against ``min_temp``/``max_temp``.
+    Legitimate low presets such as ``PRESET_ANTI_FREEZE`` (5°C) sit below the
+    default ``min_temp`` of 7°C and must still be honored.
+    """
+    if value is None:
+        return None
+
+    temp = float(value)
+
+    if temp <= 0:
+        _LOGGER.warning(
+            "Ignoring preset %s=%s because it is a placeholder (<= 0)",
+            field_name,
+            temp,
+        )
+        return None
+
+    return temp
+
+
 class TargeTempEnv:
     temperature: float | None
 
@@ -133,22 +163,32 @@ class PresetEnv(TempEnv, HumidityEnv):
             _LOGGER.debug(f"PresetEnv: Could not extract entities from template: {e}")
 
     def get_temperature(self, hass: HomeAssistant) -> float | None:
-        """Get temperature, evaluating template if needed."""
+        """Get temperature, evaluating template if needed.
+
+        Placeholder values (<= 0) are filtered to None here so every consumer
+        — apply, restore, and template re-evaluation — gets the same guard.
+        """
         if "temperature" in self._template_fields:
-            return self._evaluate_template(hass, "temperature")
-        return self.temperature
+            value = self._evaluate_template(hass, "temperature")
+        else:
+            value = self.temperature
+        return normalize_preset_temperature(value, "temperature")
 
     def get_target_temp_low(self, hass: HomeAssistant) -> float | None:
         """Get target_temp_low, evaluating template if needed."""
         if "target_temp_low" in self._template_fields:
-            return self._evaluate_template(hass, "target_temp_low")
-        return self.target_temp_low
+            value = self._evaluate_template(hass, "target_temp_low")
+        else:
+            value = self.target_temp_low
+        return normalize_preset_temperature(value, "target_temp_low")
 
     def get_target_temp_high(self, hass: HomeAssistant) -> float | None:
         """Get target_temp_high, evaluating template if needed."""
         if "target_temp_high" in self._template_fields:
-            return self._evaluate_template(hass, "target_temp_high")
-        return self.target_temp_high
+            value = self._evaluate_template(hass, "target_temp_high")
+        else:
+            value = self.target_temp_high
+        return normalize_preset_temperature(value, "target_temp_high")
 
     def _evaluate_template(self, hass: HomeAssistant, field_name: str) -> float:
         """Safely evaluate template with fallback to previous value."""

--- a/tests/managers/test_environment_manager.py
+++ b/tests/managers/test_environment_manager.py
@@ -75,40 +75,6 @@ class TestSetHvacMode:
         assert environment_manager._hvac_mode == HVACMode.FAN_ONLY
 
 
-class TestPresetTemperatureValidation:
-    """Test preset temperature validation helpers."""
-
-    def test_zero_placeholder_is_ignored(self, environment_manager):
-        """Preset placeholders like 0 should be treated as unset."""
-        preset_env = PresetEnv(temperature=0)
-
-        assert environment_manager.get_validated_preset_temperature(preset_env) is None
-
-    def test_negative_placeholder_is_ignored(self, environment_manager):
-        """Negative preset temperatures are non-physical placeholders and ignored."""
-        preset_env = PresetEnv(temperature=-5)
-
-        assert environment_manager.get_validated_preset_temperature(preset_env) is None
-
-    def test_valid_preset_temperature_is_kept(self, environment_manager):
-        """A normal in-range temperature should pass through unchanged."""
-        preset_env = PresetEnv(temperature=21.5)
-
-        assert environment_manager.get_validated_preset_temperature(preset_env) == 21.5
-
-    def test_low_preset_below_min_temp_is_kept(self, environment_manager):
-        """Legitimate low presets (e.g. anti-freeze at 5°C) must survive the
-        placeholder guard even though they sit below the default min_temp of 7°C.
-
-        The guard rejects non-physical placeholders (<= 0), NOT values below the
-        configured min_temp — clamping to min_temp would silently break the
-        anti-freeze preset (regression guard for PR #598).
-        """
-        preset_env = PresetEnv(temperature=5)
-
-        assert environment_manager.get_validated_preset_temperature(preset_env) == 5
-
-
 class TestGetActiveToleranceForMode:
     """Test _get_active_tolerance_for_mode() method."""
 

--- a/tests/managers/test_environment_manager.py
+++ b/tests/managers/test_environment_manager.py
@@ -75,6 +75,22 @@ class TestSetHvacMode:
         assert environment_manager._hvac_mode == HVACMode.FAN_ONLY
 
 
+class TestPresetTemperatureValidation:
+    """Test preset temperature validation helpers."""
+
+    def test_zero_placeholder_below_min_temp_is_ignored(self, environment_manager):
+        """Preset placeholders like 0 should be treated as unset when below bounds."""
+        preset_env = PresetEnv(temperature=0)
+
+        assert environment_manager.get_validated_preset_temperature(preset_env) is None
+
+    def test_valid_preset_temperature_within_bounds_is_kept(self, environment_manager):
+        """Temperatures inside configured bounds should pass through unchanged."""
+        preset_env = PresetEnv(temperature=21.5)
+
+        assert environment_manager.get_validated_preset_temperature(preset_env) == 21.5
+
+
 class TestGetActiveToleranceForMode:
     """Test _get_active_tolerance_for_mode() method."""
 

--- a/tests/managers/test_environment_manager.py
+++ b/tests/managers/test_environment_manager.py
@@ -78,17 +78,35 @@ class TestSetHvacMode:
 class TestPresetTemperatureValidation:
     """Test preset temperature validation helpers."""
 
-    def test_zero_placeholder_below_min_temp_is_ignored(self, environment_manager):
-        """Preset placeholders like 0 should be treated as unset when below bounds."""
+    def test_zero_placeholder_is_ignored(self, environment_manager):
+        """Preset placeholders like 0 should be treated as unset."""
         preset_env = PresetEnv(temperature=0)
 
         assert environment_manager.get_validated_preset_temperature(preset_env) is None
 
-    def test_valid_preset_temperature_within_bounds_is_kept(self, environment_manager):
-        """Temperatures inside configured bounds should pass through unchanged."""
+    def test_negative_placeholder_is_ignored(self, environment_manager):
+        """Negative preset temperatures are non-physical placeholders and ignored."""
+        preset_env = PresetEnv(temperature=-5)
+
+        assert environment_manager.get_validated_preset_temperature(preset_env) is None
+
+    def test_valid_preset_temperature_is_kept(self, environment_manager):
+        """A normal in-range temperature should pass through unchanged."""
         preset_env = PresetEnv(temperature=21.5)
 
         assert environment_manager.get_validated_preset_temperature(preset_env) == 21.5
+
+    def test_low_preset_below_min_temp_is_kept(self, environment_manager):
+        """Legitimate low presets (e.g. anti-freeze at 5°C) must survive the
+        placeholder guard even though they sit below the default min_temp of 7°C.
+
+        The guard rejects non-physical placeholders (<= 0), NOT values below the
+        configured min_temp — clamping to min_temp would silently break the
+        anti-freeze preset (regression guard for PR #598).
+        """
+        preset_env = PresetEnv(temperature=5)
+
+        assert environment_manager.get_validated_preset_temperature(preset_env) == 5
 
 
 class TestGetActiveToleranceForMode:

--- a/tests/managers/test_preset_manager_templates.py
+++ b/tests/managers/test_preset_manager_templates.py
@@ -33,9 +33,6 @@ class TestPresetManagerTemplateIntegration:
         config = {}
         environment = Mock()
         environment.target_temp = None
-        environment.get_validated_preset_temperature.side_effect = (
-            lambda preset: preset.get_temperature(hass)
-        )
         features = Mock()
         features.is_range_mode = False
 
@@ -77,9 +74,6 @@ class TestPresetManagerTemplateIntegration:
         environment = Mock()
         environment.target_temp = None
         environment.saved_target_temp = 20.0
-        environment.get_validated_preset_temperature.side_effect = (
-            lambda preset: preset.get_temperature(hass)
-        )
         features = Mock()
         features.is_range_mode = False
 
@@ -120,12 +114,6 @@ class TestPresetManagerTemplateIntegration:
         environment.target_temp_high = None
         environment.saved_target_temp_low = None
         environment.saved_target_temp_high = None
-        environment.get_validated_preset_temp_low.side_effect = (
-            lambda preset: preset.get_target_temp_low(hass)
-        )
-        environment.get_validated_preset_temp_high.side_effect = (
-            lambda preset: preset.get_target_temp_high(hass)
-        )
         features = Mock()
         features.is_range_mode = True
 

--- a/tests/managers/test_preset_manager_templates.py
+++ b/tests/managers/test_preset_manager_templates.py
@@ -9,6 +9,10 @@ import pytest
 from custom_components.dual_smart_thermostat.managers.preset_manager import (
     PresetManager,
 )
+from custom_components.dual_smart_thermostat.managers.environment_manager import (
+    EnvironmentManager,
+)
+from custom_components.dual_smart_thermostat.const import CONF_SENSOR
 from custom_components.dual_smart_thermostat.preset_env.preset_env import PresetEnv
 
 
@@ -29,6 +33,9 @@ class TestPresetManagerTemplateIntegration:
         config = {}
         environment = Mock()
         environment.target_temp = None
+        environment.get_validated_preset_temperature.side_effect = (
+            lambda preset: preset.get_temperature(hass)
+        )
         features = Mock()
         features.is_range_mode = False
 
@@ -70,6 +77,9 @@ class TestPresetManagerTemplateIntegration:
         environment = Mock()
         environment.target_temp = None
         environment.saved_target_temp = 20.0
+        environment.get_validated_preset_temperature.side_effect = (
+            lambda preset: preset.get_temperature(hass)
+        )
         features = Mock()
         features.is_range_mode = False
 
@@ -110,6 +120,12 @@ class TestPresetManagerTemplateIntegration:
         environment.target_temp_high = None
         environment.saved_target_temp_low = None
         environment.saved_target_temp_high = None
+        environment.get_validated_preset_temp_low.side_effect = (
+            lambda preset: preset.get_target_temp_low(hass)
+        )
+        environment.get_validated_preset_temp_high.side_effect = (
+            lambda preset: preset.get_target_temp_high(hass)
+        )
         features = Mock()
         features.is_range_mode = True
 
@@ -130,3 +146,27 @@ class TestPresetManagerTemplateIntegration:
         # Assert: Both temps set from templates (outdoor_temp = 20 in fixture)
         assert environment.target_temp_low == 18.0  # 20 - 2
         assert environment.target_temp_high == 24.0  # 20 + 4
+
+    @pytest.mark.asyncio
+    async def test_preset_manager_ignores_legacy_zero_temperature_placeholder(
+        self, hass: HomeAssistant
+    ):
+        """Legacy preset temperature=0 should not overwrite a valid target."""
+        environment = EnvironmentManager(hass, {CONF_SENSOR: "sensor.temperature"})
+        environment.target_temp = 21.0
+        features = Mock()
+        features.is_range_mode = False
+
+        preset_manager = PresetManager(hass, {}, environment, features)
+        preset_manager._presets = {"away": 0.0}
+        preset_manager._preset_modes = ["away"]
+
+        old_state = Mock()
+        old_state.attributes = {
+            "preset_mode": "away",
+            "temperature": None,
+        }
+
+        await preset_manager.apply_old_state(old_state)
+
+        assert environment.target_temp == 21.0

--- a/tests/managers/test_preset_manager_templates.py
+++ b/tests/managers/test_preset_manager_templates.py
@@ -6,13 +6,13 @@ from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 import pytest
 
-from custom_components.dual_smart_thermostat.managers.preset_manager import (
-    PresetManager,
-)
+from custom_components.dual_smart_thermostat.const import CONF_SENSOR
 from custom_components.dual_smart_thermostat.managers.environment_manager import (
     EnvironmentManager,
 )
-from custom_components.dual_smart_thermostat.const import CONF_SENSOR
+from custom_components.dual_smart_thermostat.managers.preset_manager import (
+    PresetManager,
+)
 from custom_components.dual_smart_thermostat.preset_env.preset_env import PresetEnv
 
 

--- a/tests/preset_env/test_preset_env_templates.py
+++ b/tests/preset_env/test_preset_env_templates.py
@@ -332,3 +332,71 @@ class TestRangeModeWithTemplates:
         # Assert: Static unchanged, template updated
         assert temp_low_after == 18.0  # Still static
         assert temp_high_after == 29.0  # 25 + 4 from updated template
+
+
+class TestPlaceholderTemperatureGuard:
+    """Placeholder temperatures (<= 0) are filtered to None by the getters.
+
+    Some real-world configs use temperature: 0 (or negative) as an "unset"
+    placeholder; applying it would overwrite a valid target. The guard lives
+    in PresetEnv's getters so static values, lazily-rendered templates, and
+    every consumer (apply, restore, template re-evaluation) are all covered.
+    """
+
+    @pytest.mark.asyncio
+    async def test_zero_placeholder_is_ignored(self, hass: HomeAssistant):
+        """Static temperature=0 placeholder should read as unset."""
+        preset_env = PresetEnv(**{ATTR_TEMPERATURE: 0})
+
+        assert preset_env.get_temperature(hass) is None
+
+    @pytest.mark.asyncio
+    async def test_negative_placeholder_is_ignored(self, hass: HomeAssistant):
+        """Negative temperatures are non-physical placeholders and ignored."""
+        preset_env = PresetEnv(**{ATTR_TEMPERATURE: -5})
+
+        assert preset_env.get_temperature(hass) is None
+
+    @pytest.mark.asyncio
+    async def test_valid_temperature_is_kept(self, hass: HomeAssistant):
+        """A normal temperature passes through unchanged."""
+        preset_env = PresetEnv(**{ATTR_TEMPERATURE: 21.5})
+
+        assert preset_env.get_temperature(hass) == 21.5
+
+    @pytest.mark.asyncio
+    async def test_low_preset_below_min_temp_is_kept(self, hass: HomeAssistant):
+        """Legitimate low presets (e.g. anti-freeze at 5°C) must survive the
+        placeholder guard even though they sit below the default min_temp of
+        7°C. The guard rejects non-physical placeholders (<= 0), NOT values
+        below the configured min_temp (regression guard for PR #598).
+        """
+        preset_env = PresetEnv(**{ATTR_TEMPERATURE: 5})
+
+        assert preset_env.get_temperature(hass) == 5
+
+    @pytest.mark.asyncio
+    async def test_zero_range_placeholders_are_ignored(self, hass: HomeAssistant):
+        """Range getters apply the same placeholder guard."""
+        preset_env = PresetEnv(**{ATTR_TARGET_TEMP_LOW: 0, ATTR_TARGET_TEMP_HIGH: 0})
+
+        assert preset_env.get_target_temp_low(hass) is None
+        assert preset_env.get_target_temp_high(hass) is None
+
+    @pytest.mark.asyncio
+    async def test_template_rendering_placeholder_is_ignored(self, hass: HomeAssistant):
+        """A template that renders to 0 at apply time reads as unset too."""
+        hass.states.async_set("sensor.away_temp", "0")
+        await hass.async_block_till_done()
+
+        preset_env = PresetEnv(
+            **{ATTR_TEMPERATURE: "{{ states('sensor.away_temp') | float }}"}
+        )
+
+        assert preset_env.get_temperature(hass) is None
+
+        # Once the sensor reports a real value, the preset applies again
+        hass.states.async_set("sensor.away_temp", "16")
+        await hass.async_block_till_done()
+
+        assert preset_env.get_temperature(hass) == 16.0


### PR DESCRIPTION
## Summary
- ignore preset temperatures that fall outside the thermostat min/max bounds before applying them
- reuse the same validation when restoring preset values from old state and legacy preset formats
- add focused tests covering zero placeholder values and the updated PresetManager/environment contract

## Why
Some real-world configs use `temperature: 0` as a placeholder inside preset definitions. When those values are restored or applied, they can overwrite a valid target temperature even though `0` is below the thermostat's configured minimum.

## Testing
- `.venv/bin/python -m pytest -q tests/managers/test_environment_manager.py tests/managers/test_preset_manager_templates.py`
