### PR TITLE
fix: use dual setpoints for HEAT_COOL tolerance selection (#612)

### DIFF
--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -410,30 +410,29 @@ class EnvironmentManager(StateManager):
         # HEAT_COOL (Auto): Determine operation from the dual setpoints.
         # Below target_temp_low -> heating; above target_temp_high -> cooling;
         # inside the deadband -> no active demand (falls through to legacy).
-        elif self._hvac_mode == HVACMode.HEAT_COOL:
-            if self._cur_temp is not None:
-                if (
-                    self._target_temp_low is not None
-                    and self._cur_temp < self._target_temp_low
-                ):
-                    # Currently heating
-                    if self._heat_tolerance is not None:
-                        _LOGGER.debug(
-                            "Using heat_tolerance for HEAT_COOL mode (heating): %s",
-                            self._heat_tolerance,
-                        )
-                        return (self._heat_tolerance, self._heat_tolerance)
-                elif (
-                    self._target_temp_high is not None
-                    and self._cur_temp > self._target_temp_high
-                ):
-                    # Currently cooling
-                    if self._cool_tolerance is not None:
-                        _LOGGER.debug(
-                            "Using cool_tolerance for HEAT_COOL mode (cooling): %s",
-                            self._cool_tolerance,
-                        )
-                        return (self._cool_tolerance, self._cool_tolerance)
+        elif self._hvac_mode == HVACMode.HEAT_COOL and self._cur_temp is not None:
+            # Currently heating (below low setpoint)
+            if (
+                self._target_temp_low is not None
+                and self._cur_temp < self._target_temp_low
+                and self._heat_tolerance is not None
+            ):
+                _LOGGER.debug(
+                    "Using heat_tolerance for HEAT_COOL mode (heating): %s",
+                    self._heat_tolerance,
+                )
+                return (self._heat_tolerance, self._heat_tolerance)
+            # Currently cooling (above high setpoint)
+            if (
+                self._target_temp_high is not None
+                and self._cur_temp > self._target_temp_high
+                and self._cool_tolerance is not None
+            ):
+                _LOGGER.debug(
+                    "Using cool_tolerance for HEAT_COOL mode (cooling): %s",
+                    self._cool_tolerance,
+                )
+                return (self._cool_tolerance, self._cool_tolerance)
 
         # Fallback: Use legacy tolerances (with defaults if not configured)
         cold_tol = (

--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -407,10 +407,15 @@ class EnvironmentManager(StateManager):
                 )
                 return (self._cool_tolerance, self._cool_tolerance)
 
-        # HEAT_COOL (Auto): Determine operation from temperature
+        # HEAT_COOL (Auto): Determine operation from the dual setpoints.
+        # Below target_temp_low -> heating; above target_temp_high -> cooling;
+        # inside the deadband -> no active demand (falls through to legacy).
         elif self._hvac_mode == HVACMode.HEAT_COOL:
-            if self._cur_temp is not None and self._target_temp is not None:
-                if self._cur_temp < self._target_temp:
+            if self._cur_temp is not None:
+                if (
+                    self._target_temp_low is not None
+                    and self._cur_temp < self._target_temp_low
+                ):
                     # Currently heating
                     if self._heat_tolerance is not None:
                         _LOGGER.debug(
@@ -418,7 +423,10 @@ class EnvironmentManager(StateManager):
                             self._heat_tolerance,
                         )
                         return (self._heat_tolerance, self._heat_tolerance)
-                else:
+                elif (
+                    self._target_temp_high is not None
+                    and self._cur_temp > self._target_temp_high
+                ):
                     # Currently cooling
                     if self._cool_tolerance is not None:
                         _LOGGER.debug(

--- a/tests/managers/test_environment_manager.py
+++ b/tests/managers/test_environment_manager.py
@@ -121,11 +121,12 @@ class TestGetActiveToleranceForMode:
     async def test_heat_cool_mode_heating_uses_heat_tolerance(
         self, hass, environment_manager_with_tolerances
     ):
-        """Test HEAT_COOL mode uses heat_tolerance when currently heating."""
+        """Test HEAT_COOL mode uses heat_tolerance when below the low setpoint."""
         env = environment_manager_with_tolerances
         env.set_hvac_mode(HVACMode.HEAT_COOL)
-        env._target_temp = 21.0
-        env._cur_temp = 20.0  # Below target -> heating
+        env._target_temp_low = 19.0
+        env._target_temp_high = 24.0
+        env._cur_temp = 18.0  # Below low setpoint -> heating
 
         cold_tol, hot_tol = env._get_active_tolerance_for_mode()
 
@@ -136,16 +137,36 @@ class TestGetActiveToleranceForMode:
     async def test_heat_cool_mode_cooling_uses_cool_tolerance(
         self, hass, environment_manager_with_tolerances
     ):
-        """Test HEAT_COOL mode uses cool_tolerance when currently cooling."""
+        """Test HEAT_COOL mode uses cool_tolerance when above the high setpoint."""
         env = environment_manager_with_tolerances
         env.set_hvac_mode(HVACMode.HEAT_COOL)
-        env._target_temp = 21.0
-        env._cur_temp = 22.0  # Above target -> cooling
+        env._target_temp_low = 19.0
+        env._target_temp_high = 24.0
+        env._cur_temp = 25.0  # Above high setpoint -> cooling
 
         cold_tol, hot_tol = env._get_active_tolerance_for_mode()
 
         assert cold_tol == 2.0  # cool_tolerance
         assert hot_tol == 2.0  # cool_tolerance
+
+    @pytest.mark.asyncio
+    async def test_heat_cool_mode_deadband_uses_legacy(
+        self, hass, environment_manager_with_tolerances
+    ):
+        """Inside the deadband (between low/high), no mode-specific tolerance
+        applies. Regression for #612: the heat/cool decision must use the dual
+        setpoints, not the single _target_temp (which would mis-pick cool_tol).
+        """
+        env = environment_manager_with_tolerances
+        env.set_hvac_mode(HVACMode.HEAT_COOL)
+        env._target_temp_low = 19.0
+        env._target_temp_high = 24.0
+        env._cur_temp = 21.0  # Between setpoints -> no active demand
+
+        cold_tol, hot_tol = env._get_active_tolerance_for_mode()
+
+        assert cold_tol == 0.5  # legacy cold_tolerance
+        assert hot_tol == 0.5  # legacy hot_tolerance
 
     @pytest.mark.asyncio
     async def test_legacy_fallback_when_heat_tolerance_none(


### PR DESCRIPTION
Fixes #612.

## Problem
In HEAT_COOL (Auto) mode, `_get_active_tolerance_for_mode` decided heating-vs-cooling by comparing `cur_temp` against the single `_target_temp` — which is unset/stale when dual setpoints (`target_temp_low`/`target_temp_high`) are in use. The wrong tolerance got picked: e.g. `cool_tolerance: 0.5` was applied so the cooler started at 24.5°C instead of the configured 24.0°C. Reported and root-caused by @Philmo67.

## Fix
Compare `cur_temp` against the dual setpoints:
- below `target_temp_low` → heating → `heat_tolerance`
- above `target_temp_high` → cooling → `cool_tolerance`
- inside the deadband → legacy `cold`/`hot` tolerances

## Tests
- Updated the two HEAT_COOL tolerance tests to use dual setpoints
- Added a deadband regression test (the 24.0-vs-24.5 case)
- Full suite: 1531 passed, 2 skipped