### PR TITLE
ci: Dependabot monthly + group minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,11 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
     reviewers:
       - "dependabot[bot]"
@@ -17,8 +20,11 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
     reviewers:
       - "dependabot[bot]"


### PR DESCRIPTION
Reduce Dependabot churn & Actions cost: version updates monthly instead of weekly/daily, and minor+patch grouped into a single PR per ecosystem (majors stay individual so they get attention). Security updates are unaffected (they remain immediate).
