### PR TITLE
fix: directional tolerances per loop in HEAT_COOL mode (#612)

### DIFF
--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -364,93 +364,68 @@ class EnvironmentManager(StateManager):
         _LOGGER.debug("Setting HVAC mode for tolerance selection: %s", hvac_mode)
         self._hvac_mode = hvac_mode
 
-    def _get_active_tolerance_for_mode(self) -> tuple[float, float]:
-        """Get active cold and hot tolerance values for current HVAC mode.
+    def _get_active_tolerance_for_mode(
+        self, target_attr: str = "_target_temp"
+    ) -> tuple[float, float]:
+        """Get active (cold, hot) tolerance values for the current check.
 
-        Implements priority-based tolerance selection:
-          Priority 1: Mode-specific tolerance (heat_tolerance or cool_tolerance)
-          Priority 2: Legacy tolerances (cold_tolerance, hot_tolerance)
+        ``cold`` is used by ``is_too_cold`` (current temp below target) and
+        ``hot`` by ``is_too_hot`` (current temp above target). The cold/hot
+        legacy tolerances are *directional* (they always describe the
+        below/above-target side); the mode tolerances are the per-mode
+        hysteresis.
 
-        Returns:
-            tuple[float, float]: (cold_tolerance, hot_tolerance) to use for comparisons
-                Both values are always valid floats (never None)
-
-        Notes:
-            - For HEAT mode: Returns (heat_tol, heat_tol) if set, else legacy
-            - For COOL mode: Returns (cool_tol, cool_tol) if set, else legacy
-            - For HEAT_COOL: Checks current vs target temp to determine operation
-            - For FAN_ONLY: Uses cool_tolerance (fan behaves like cooling)
-            - For DRY/OFF: Returns legacy (no active tolerance checks)
-            - If _hvac_mode is None: Returns legacy (safe fallback)
+        Selection (issue #612):
+            - HEAT_COOL has two independent loops keyed by ``target_attr``:
+                * ``_target_temp_low`` (heater): start below low uses
+                  ``cold_tolerance``; stop above low uses ``heat_tolerance``
+                  (falls back to legacy hot tolerance when unset).
+                * ``_target_temp_high`` (cooler): start above high uses
+                  ``hot_tolerance``; stop below high uses ``cool_tolerance``
+                  (falls back to legacy cold tolerance when unset).
+            - HEAT: symmetric ``heat_tolerance`` if configured.
+            - COOL / FAN_ONLY: symmetric ``cool_tolerance`` if configured.
+            - Otherwise: legacy directional tolerances.
+        Both returned values are always valid floats (never None).
         """
-        # HEAT mode: Use heat_tolerance if configured
-        if self._hvac_mode == HVACMode.HEAT:
-            if self._heat_tolerance is not None:
-                _LOGGER.debug(
-                    "Using heat_tolerance for HEAT mode: %s", self._heat_tolerance
-                )
-                return (self._heat_tolerance, self._heat_tolerance)
-
-        # COOL mode: Use cool_tolerance if configured
-        elif self._hvac_mode == HVACMode.COOL:
-            if self._cool_tolerance is not None:
-                _LOGGER.debug(
-                    "Using cool_tolerance for COOL mode: %s", self._cool_tolerance
-                )
-                return (self._cool_tolerance, self._cool_tolerance)
-
-        # FAN_ONLY: Use cool_tolerance (fan behaves like cooling)
-        elif self._hvac_mode == HVACMode.FAN_ONLY:
-            if self._cool_tolerance is not None:
-                _LOGGER.debug(
-                    "Using cool_tolerance for FAN_ONLY mode: %s", self._cool_tolerance
-                )
-                return (self._cool_tolerance, self._cool_tolerance)
-
-        # HEAT_COOL (Auto): Determine operation from the dual setpoints.
-        # Below target_temp_low -> heating; above target_temp_high -> cooling;
-        # inside the deadband -> no active demand (falls through to legacy).
-        elif self._hvac_mode == HVACMode.HEAT_COOL and self._cur_temp is not None:
-            # Currently heating (below low setpoint)
-            if (
-                self._target_temp_low is not None
-                and self._cur_temp < self._target_temp_low
-                and self._heat_tolerance is not None
-            ):
-                _LOGGER.debug(
-                    "Using heat_tolerance for HEAT_COOL mode (heating): %s",
-                    self._heat_tolerance,
-                )
-                return (self._heat_tolerance, self._heat_tolerance)
-            # Currently cooling (above high setpoint)
-            if (
-                self._target_temp_high is not None
-                and self._cur_temp > self._target_temp_high
-                and self._cool_tolerance is not None
-            ):
-                _LOGGER.debug(
-                    "Using cool_tolerance for HEAT_COOL mode (cooling): %s",
-                    self._cool_tolerance,
-                )
-                return (self._cool_tolerance, self._cool_tolerance)
-
-        # Fallback: Use legacy tolerances (with defaults if not configured)
-        cold_tol = (
+        legacy_cold = (
             self._cold_tolerance
             if self._cold_tolerance is not None
             else DEFAULT_TOLERANCE
         )
-        hot_tol = (
+        legacy_hot = (
             self._hot_tolerance
             if self._hot_tolerance is not None
             else DEFAULT_TOLERANCE
         )
-        _LOGGER.debug(
-            "Using legacy tolerances (or defaults): cold=%s, hot=%s",
-            cold_tol,
-            hot_tol,
-        )
-        return (cold_tol, hot_tol)
+
+        if self._hvac_mode == HVACMode.HEAT_COOL:
+            if target_attr == "_target_temp_low":
+                hot = (
+                    self._heat_tolerance
+                    if self._heat_tolerance is not None
+                    else legacy_hot
+                )
+                return (legacy_cold, hot)
+            if target_attr == "_target_temp_high":
+                cold = (
+                    self._cool_tolerance
+                    if self._cool_tolerance is not None
+                    else legacy_cold
+                )
+                return (cold, legacy_hot)
+            return (legacy_cold, legacy_hot)
+
+        if self._hvac_mode == HVACMode.HEAT and self._heat_tolerance is not None:
+            return (self._heat_tolerance, self._heat_tolerance)
+
+        if (
+            self._hvac_mode in (HVACMode.COOL, HVACMode.FAN_ONLY)
+            and self._cool_tolerance is not None
+        ):
+            return (self._cool_tolerance, self._cool_tolerance)
+
+        return (legacy_cold, legacy_hot)
 
     def set_temperature_range_from_saved(self) -> None:
         self.target_temp_low = self.saved_target_temp_low
@@ -547,7 +522,7 @@ class EnvironmentManager(StateManager):
         if self._cur_temp is None or target_temp is None:
             return False
 
-        cold_tolerance, _ = self._get_active_tolerance_for_mode()
+        cold_tolerance, _ = self._get_active_tolerance_for_mode(target_attr)
 
         _LOGGER.debug(
             "is_too_cold - target temp attr: %s, Target temp: %s, current temp: %s, tolerance: %s",
@@ -571,7 +546,7 @@ class EnvironmentManager(StateManager):
         if active_temp is None or target_temp is None:
             return False
 
-        _, hot_tolerance = self._get_active_tolerance_for_mode()
+        _, hot_tolerance = self._get_active_tolerance_for_mode(target_attr)
 
         _LOGGER.debug(
             "is_too_hot - target temp attr: %s, Target temp: %s, "

--- a/tests/managers/test_environment_manager.py
+++ b/tests/managers/test_environment_manager.py
@@ -118,55 +118,89 @@ class TestGetActiveToleranceForMode:
         assert hot_tol == 2.0  # cool_tolerance
 
     @pytest.mark.asyncio
-    async def test_heat_cool_mode_heating_uses_heat_tolerance(
+    async def test_heat_cool_heater_loop_directional_tolerances(
         self, hass, environment_manager_with_tolerances
     ):
-        """Test HEAT_COOL mode uses heat_tolerance when below the low setpoint."""
+        """HEAT_COOL heater loop (low setpoint): start below low uses the
+        directional cold_tolerance, stop above low uses heat_tolerance (#612)."""
         env = environment_manager_with_tolerances
         env.set_hvac_mode(HVACMode.HEAT_COOL)
-        env._target_temp_low = 19.0
-        env._target_temp_high = 24.0
-        env._cur_temp = 18.0  # Below low setpoint -> heating
 
-        cold_tol, hot_tol = env._get_active_tolerance_for_mode()
+        cold_tol, hot_tol = env._get_active_tolerance_for_mode("_target_temp_low")
 
-        assert cold_tol == 0.3  # heat_tolerance
-        assert hot_tol == 0.3  # heat_tolerance
+        assert cold_tol == 0.5  # cold_tolerance -> heater start below low
+        assert hot_tol == 0.3  # heat_tolerance -> heater stop above low
 
     @pytest.mark.asyncio
-    async def test_heat_cool_mode_cooling_uses_cool_tolerance(
+    async def test_heat_cool_cooler_loop_directional_tolerances(
         self, hass, environment_manager_with_tolerances
     ):
-        """Test HEAT_COOL mode uses cool_tolerance when above the high setpoint."""
+        """HEAT_COOL cooler loop (high setpoint): start above high uses the
+        directional hot_tolerance, stop below high uses cool_tolerance (#612)."""
         env = environment_manager_with_tolerances
         env.set_hvac_mode(HVACMode.HEAT_COOL)
-        env._target_temp_low = 19.0
-        env._target_temp_high = 24.0
-        env._cur_temp = 25.0  # Above high setpoint -> cooling
 
-        cold_tol, hot_tol = env._get_active_tolerance_for_mode()
+        cold_tol, hot_tol = env._get_active_tolerance_for_mode("_target_temp_high")
 
-        assert cold_tol == 2.0  # cool_tolerance
-        assert hot_tol == 2.0  # cool_tolerance
+        assert cold_tol == 2.0  # cool_tolerance -> cooler stop below high
+        assert hot_tol == 0.5  # hot_tolerance -> cooler start above high
 
     @pytest.mark.asyncio
-    async def test_heat_cool_mode_deadband_uses_legacy(
-        self, hass, environment_manager_with_tolerances
-    ):
-        """Inside the deadband (between low/high), no mode-specific tolerance
-        applies. Regression for #612: the heat/cool decision must use the dual
-        setpoints, not the single _target_temp (which would mis-pick cool_tol).
-        """
-        env = environment_manager_with_tolerances
+    async def test_heat_cool_mode_mode_tolerances_fall_back_to_legacy(self, hass):
+        """When heat/cool tolerances are unset, each loop falls back to the
+        legacy directional tolerances (backward compatible)."""
+        config = {
+            CONF_SENSOR: "sensor.temperature",
+            CONF_COLD_TOLERANCE: 0.4,
+            CONF_HOT_TOLERANCE: 0.6,
+        }
+        env = EnvironmentManager(hass, config)
+        env.set_hvac_mode(HVACMode.HEAT_COOL)
+
+        assert env._get_active_tolerance_for_mode("_target_temp_low") == (0.4, 0.6)
+        assert env._get_active_tolerance_for_mode("_target_temp_high") == (0.4, 0.6)
+
+    @pytest.mark.asyncio
+    async def test_heat_cool_cooler_starts_at_high_plus_hot_tolerance(self, hass):
+        """Regression #612: cooler starts at target_high + hot_tolerance, NOT
+        + cool_tolerance. With hot_tolerance=0 it must start exactly at high."""
+        config = {
+            CONF_SENSOR: "sensor.temperature",
+            CONF_COLD_TOLERANCE: 0.0,
+            CONF_HOT_TOLERANCE: 0.0,
+            CONF_HEAT_TOLERANCE: 0.3,
+            CONF_COOL_TOLERANCE: 0.5,
+        }
+        env = EnvironmentManager(hass, config)
+        env.set_hvac_mode(HVACMode.HEAT_COOL)
+        env._target_temp_high = 24.0
+
+        env._cur_temp = 24.2  # above high -> cooler should start (not wait for 24.5)
+        assert env.is_too_hot("_target_temp_high") is True
+
+        env._cur_temp = 23.8  # below high - cool_tolerance(0.5)=23.5 -> stop
+        assert env.is_too_cold("_target_temp_high") is False
+        env._cur_temp = 23.4  # below 23.5 -> cooler stops
+        assert env.is_too_cold("_target_temp_high") is True
+
+    @pytest.mark.asyncio
+    async def test_heat_cool_heater_stops_at_low_plus_heat_tolerance(self, hass):
+        """Regression #612: heater runs until target_low + heat_tolerance."""
+        config = {
+            CONF_SENSOR: "sensor.temperature",
+            CONF_COLD_TOLERANCE: 0.0,
+            CONF_HOT_TOLERANCE: 0.0,
+            CONF_HEAT_TOLERANCE: 0.3,
+            CONF_COOL_TOLERANCE: 0.5,
+        }
+        env = EnvironmentManager(hass, config)
         env.set_hvac_mode(HVACMode.HEAT_COOL)
         env._target_temp_low = 19.0
-        env._target_temp_high = 24.0
-        env._cur_temp = 21.0  # Between setpoints -> no active demand
 
-        cold_tol, hot_tol = env._get_active_tolerance_for_mode()
-
-        assert cold_tol == 0.5  # legacy cold_tolerance
-        assert hot_tol == 0.5  # legacy hot_tolerance
+        env._cur_temp = 19.2  # below low + heat_tolerance(0.3)=19.3 -> keep heating
+        assert env.is_too_hot("_target_temp_low") is False
+        env._cur_temp = 19.4  # above 19.3 -> heater stops
+        assert env.is_too_hot("_target_temp_low") is True
 
     @pytest.mark.asyncio
     async def test_legacy_fallback_when_heat_tolerance_none(


### PR DESCRIPTION
Fixes #612 (supersedes the partial fix in #613).

## Problem
In Auto (HEAT_COOL) mode the wrong tolerance was applied. `cold_tolerance`/`hot_tolerance` are **directional** (they describe the below/above-target side), but `_get_active_tolerance_for_mode` inferred heating-vs-cooling from the current temperature's *position* and returned a single mode tolerance for **both** sides. Net effect with `cool_tolerance: 0.5`: the cooler started at `high + 0.5` (24.5) instead of `high + hot_tolerance` (24.0), and the heater stop threshold fell back to legacy in the deadband.

## Fix
Pick the tolerance from the `(direction, setpoint)` context the callers already pass — `is_too_cold`/`is_too_hot` know the direction, and `target_attr` identifies which loop — instead of guessing from `cur_temp`:

| check | role | tolerance |
|---|---|---|
| `is_too_cold("_target_temp_low")` | heater start | `cold_tolerance` |
| `is_too_hot("_target_temp_low")` | heater stop | `heat_tolerance` |
| `is_too_hot("_target_temp_high")` | cooler start | `hot_tolerance` |
| `is_too_cold("_target_temp_high")` | cooler stop | `cool_tolerance` |

Mode tolerances fall back to the legacy directional ones when unset, so **configs without `heat`/`cool` tolerances are unchanged** (full suite confirms). Single HEAT/COOL/FAN modes keep their symmetric ±mode-tolerance behavior.

## Tests
- Directional tolerance selection for each loop
- Backward-compat fallback to legacy when mode tolerances unset
- Behavioral regressions: cooler starts at `high + hot_tolerance` (not `+ cool_tolerance`); heater runs until `low + heat_tolerance`
- Full suite: 1533 passed, 2 skipped

## Follow-up
The `specs/002-separate-tolerances` quickstart describes `heat`/`cool` as symmetric `±`; the HEAT_COOL section there should be updated to document the directional model. Not included here to keep the fix focused.

Thanks @Philmo67 for the precise root-cause.