### PR TITLE
chore(deps-dev): PHACC 0.13.348 (HA 2026.7.4) + fix control-loop scheduling race

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,7 @@ LABEL maintainer="Dual Smart Thermostat Contributors"
 LABEL description="Development environment for Dual Smart Thermostat Home Assistant integration"
 
 # Build arguments
-ARG HA_VERSION=2026.6.4
+ARG HA_VERSION=2026.7.4
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Environment variables

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -1446,6 +1446,12 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
                     self.sensor_entity_id,
                     new_state,
                 )
+                # The reason still held everywhere is the pre-stall one: the
+                # emergency stop turned the device off without a controller
+                # deciding anything. Clear it down the whole device tree so the
+                # control run below starts from a clean slate - if the fresh
+                # reading calls for no action, no stale reason resurfaces.
+                self.hvac_device.reset_hvac_action_reason()
                 self._hvac_action_reason = self.hvac_device.HVACActionReason
                 self._publish_hvac_action_reason(self._hvac_action_reason)
                 self.async_write_ha_state()

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -1805,7 +1805,10 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         if new_state is None:
             return
         if old_state is None:
-            self.hass.create_task(self._check_device_initial_state())
+            # async_create_task (eager) not create_task: we are already on the
+            # event loop, and create_task's call_soon_threadsafe defers the run
+            # by a loop iteration, racing whatever the caller does next.
+            self.hass.async_create_task(self._check_device_initial_state())
 
         self.async_write_ha_state()
 
@@ -1818,7 +1821,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
             _LOGGER.debug(
                 "Resuming from state. Old state is None, New State: %s", new_state
             )
-            self.hass.create_task(self._async_control_climate())
+            self.hass.async_create_task(self._async_control_climate())
 
         if old_state is not None and new_state is not None:
             _LOGGER.debug(
@@ -1833,7 +1836,7 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
-                self.hass.create_task(self._async_control_climate())
+                self.hass.async_create_task(self._async_control_climate())
 
     @property
     def _is_device_active(self) -> bool:

--- a/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
+++ b/custom_components/dual_smart_thermostat/hvac_controller/generic_controller.py
@@ -58,6 +58,10 @@ class GenericHvacController(HvacController):
     def hvac_action_reason(self) -> HVACActionReason:
         return self._hvac_action_reason
 
+    @hvac_action_reason.setter
+    def hvac_action_reason(self, hvac_action_reason: HVACActionReason) -> None:
+        self._hvac_action_reason = hvac_action_reason
+
     @property
     def is_active(self) -> bool:
         """If the toggleable hvac device is currently active."""

--- a/custom_components/dual_smart_thermostat/hvac_controller/hvac_controller.py
+++ b/custom_components/dual_smart_thermostat/hvac_controller/hvac_controller.py
@@ -95,6 +95,10 @@ class HvacController(ABC):
     def hvac_action_reason(self) -> HVACActionReason:
         return self._hvac_action_reason
 
+    @hvac_action_reason.setter
+    def hvac_action_reason(self, hvac_action_reason: HVACActionReason) -> None:
+        self._hvac_action_reason = hvac_action_reason
+
     @abstractmethod
     def async_control_device_when_on(
         self,

--- a/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
@@ -114,6 +114,17 @@ class ControlableHVACDevice(ABC):
     def HVACActionReason(self, hvac_action_reason: HVACActionReason):
         self._hvac_action_reason = hvac_action_reason
 
+    def reset_hvac_action_reason(self) -> None:
+        """Forget why the device last acted.
+
+        The reason is sticky - it is only rewritten when a controller
+        actually acts - so after something external stops the device (an
+        emergency stop, say) the stored reason no longer describes reality
+        and would be republished by the next control run that decides to do
+        nothing. Implementations must clear every copy they hold.
+        """
+        self._hvac_action_reason = HVACActionReason.NONE
+
     def on_entity_state_changed(self, entity_id: str, new_state: State) -> None:
         """Handle entity state changes. Currently only for specific cases when the devices needs"""
         pass

--- a/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/generic_hvac_device.py
@@ -129,6 +129,12 @@ class GenericHVACDevice(
         """If the toggleable hvac device is currently active."""
         return self.hvac_controller.is_active
 
+    # override
+    def reset_hvac_action_reason(self) -> None:
+        """Clear the controller's copy too - it is the one control re-reads."""
+        super().reset_hvac_action_reason()
+        self.hvac_controller.hvac_action_reason = HVACActionReason.NONE
+
     @property
     def is_on(self) -> bool:
         return self._entity_state is not None and self._entity_state.state == STATE_ON

--- a/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
@@ -46,6 +46,13 @@ class MultiHvacDevice(HVACDevice, ControlableHVACDevice):
         for device in self.hvac_devices:
             device.set_context(context)
 
+    # override
+    def reset_hvac_action_reason(self) -> None:
+        """Clear the reason on every sub-device as well as our own."""
+        super().reset_hvac_action_reason()
+        for device in self.hvac_devices:
+            device.reset_hvac_action_reason()
+
     @callback
     def on_entity_state_changed(self, entity_id: str, new_state: State) -> None:
         """Forward state-change notifications to every sub-device.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       args:
         # Change this to test with specific Home Assistant versions
         # Examples: 2025.1.0, 2025.2.0, latest
-        HA_VERSION: ${HA_VERSION:-2026.6.4}
+        HA_VERSION: ${HA_VERSION:-2026.7.4}
         PYTHON_VERSION: ${PYTHON_VERSION:-3.14}
     image: dual-smart-thermostat:dev
     container_name: dual_thermostat_dev

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 -r requirements.txt
 pip>=26.1.2,<27.0
-pytest-homeassistant-custom-component==0.13.340
+pytest-homeassistant-custom-component==0.13.348
 # Explicit pytest dependencies (may be transitive from pytest-homeassistant-custom-component)
 pytest>=8.4.2
 pytest-cov>=7.1.0
 # NOTE: pytest-asyncio is hard-pinned to ==1.3.0 by
-# pytest-homeassistant-custom-component==0.13.340, so the >=1.4.0 bump
+# pytest-homeassistant-custom-component==0.13.348, so the >=1.4.0 bump
 # (Dependabot PR #603) is incompatible and excluded for now. 1.3.0 is still
 # a 1.x release (the breaking 0.x -> 1.x major), delivered transitively.
 pytest-asyncio>=1.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,10 @@ pytest-homeassistant-custom-component==0.13.348
 # Explicit pytest dependencies (may be transitive from pytest-homeassistant-custom-component)
 pytest>=8.4.2
 pytest-cov>=7.1.0
-# NOTE: pytest-asyncio is hard-pinned to ==1.3.0 by
-# pytest-homeassistant-custom-component==0.13.348, so the >=1.4.0 bump
-# (Dependabot PR #603) is incompatible and excluded for now. 1.3.0 is still
-# a 1.x release (the breaking 0.x -> 1.x major), delivered transitively.
-pytest-asyncio>=1.3.0
+# NOTE: pytest-asyncio is hard-pinned by pytest-homeassistant-custom-component
+# (==1.4.0 as of 0.13.348), so the exact version is always delivered
+# transitively; this floor just documents the 0.x -> 1.x major.
+pytest-asyncio>=1.4.0
 # Code formatting and linting
 pre-commit
 isort

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1308,7 +1308,6 @@ def setup_switch(
     hass: HomeAssistant, is_on: bool, entity_id: str = common.ENT_SWITCH
 ) -> None:
     """Set up the test switch."""
-    hass.states.async_set(entity_id, STATE_ON if is_on else STATE_OFF)
     calls = []
 
     @callback
@@ -1316,8 +1315,13 @@ def setup_switch(
         """Log service calls."""
         calls.append(call)
 
+    # Register before setting the state: the state write dispatches the
+    # thermostat's switch-changed callback synchronously, and any service call
+    # it makes must land in `calls` rather than hit an unregistered action.
     hass.services.async_register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
     hass.services.async_register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
+
+    hass.states.async_set(entity_id, STATE_ON if is_on else STATE_OFF)
 
     return calls
 

--- a/tests/test_cooler_mode.py
+++ b/tests/test_cooler_mode.py
@@ -460,6 +460,10 @@ async def test_set_target_temp_ac_off(
     """Test if target temperature turn ac off."""
     calls = setup_switch(hass, True)
     setup_sensor(hass, 25)
+    await hass.async_block_till_done()
+    # The switch appearing drives a control run of its own; scope the
+    # assertion below to what setting the target temperature does.
+    calls.clear()
     await common.async_set_temperature(hass, 30)
     await hass.async_block_till_done()
     assert len(calls) == 1

--- a/tests/test_fan_mode.py
+++ b/tests/test_fan_mode.py
@@ -2360,7 +2360,9 @@ async def test_set_target_temp_ac_on_after_fan_tolerance(
 
     await common.async_set_temperature(hass, 22)
     await hass.async_block_till_done()
-    assert len(calls) == 4
+    # One call per set_temperature. The previous count of 4 was calibrated to
+    # the duplicated control runs that hass.create_task used to cause.
+    assert len(calls) == 2
     call = calls[1]
     assert call.domain == HASS_DOMAIN
     assert call.service == SERVICE_TURN_ON

--- a/tests/test_fan_mode.py
+++ b/tests/test_fan_mode.py
@@ -731,6 +731,10 @@ async def test_set_target_temp_fan_off(
     """Test if target temperature turn fan off."""
     calls = setup_switch(hass, True)
     setup_sensor(hass, 25)
+    await hass.async_block_till_done()
+    # The switch appearing drives a control run of its own; scope the
+    # assertion below to what setting the target temperature does.
+    calls.clear()
     await common.async_set_temperature(hass, 30)
     await hass.async_block_till_done()
     assert len(calls) == 1


### PR DESCRIPTION
Supersedes #624, which is the same bump without the fixes and fails 37 tests.

PHACC `0.13.348` pulls **homeassistant 2026.6.4 → 2026.7.4** and hard-pins **pytest-asyncio `==1.4.0`**.

Suite is green: **1535 passed, 2 skipped**.

## 1. Control-loop scheduling race

The switch state-change handlers scheduled control runs with `hass.create_task`, which defers through `loop.call_soon_threadsafe`. Those handlers are `@callback` — already on the event loop — so `create_task` is the wrong API there: it delays the control run by at least one loop iteration.

On 2026.7.4 that deferred run lands *after* the caller's next action instead of before, so the control loop fires twice and the affected tests see duplicated service calls. A real race, not a test artifact — it just happened to resolve favourably on 2026.6.4.

- `climate.py` — 3× `hass.create_task` → `hass.async_create_task` (eager)

## 2. Sticky HVAC action reason across a sensor stall

The action reason is only rewritten when a controller actually *acts*. After the emergency stop for a stalled sensor it still held the pre-stall value — nothing decided it, the device was just forced off. On recovery the next control run republished that stale reason whenever the fresh reading called for no action, so a thermostat that had reached its target kept reporting `target_temp_not_reached`.

Clearing it on the climate entity alone does not hold: `generic_hvac_device` re-reads the reason from its controller after every control run, and `_async_control_climate` re-reads it from the device. The controller's copy is authoritative and had no way to be reset.

- `HvacController` / `GenericHvacController` — `hvac_action_reason` gains a setter (was read-only)
- `ControlableHVACDevice` — new `reset_hvac_action_reason()`
- `GenericHVACDevice` — overrides it to clear the controller's copy too
- `MultiHvacDevice` — overrides it to fan out to every sub-device, matching how `on_entity_state_changed` already forwards, so composite devices (cooler+fan, heater+fan, heater+aux, heater+cooler) clear every controller they hold
- `climate.py` — reset the tree on sensor recovery, before the control run

This is a user-visible fix independent of the bump: after a temperature sensor drops out and comes back, the reported reason now reflects the current reading instead of whatever was true before the dropout.

## 3. Test adjustments

- `tests/__init__.py` — `setup_switch` registers the mock services *before* setting the state. The state write dispatches the switch-changed callback synchronously, so any service call it makes has to land in `calls` rather than hit an unregistered action.
- `test_cooler_mode.py` / `test_fan_mode.py` — clear `calls` after setup so assertions count the action under test, not the setup-time control run
- `test_fan_mode.py` — `test_set_target_temp_ac_on_after_fan_tolerance` expected 4 calls, a count calibrated to the duplicated control runs; de-duplicated it is 2

## 4. Environment

- `Dockerfile.dev`, `docker-compose.yml` — `HA_VERSION` → 2026.7.4
- `requirements-dev.txt` — `pytest-asyncio>=1.4.0`; the note about #603 being incompatible is stale, that bump is exactly what PHACC now pins

---

`dependency-audit` and `sonarcloud` are red for reasons unrelated to this PR — the former fails on master too (pillow/protobuf CVEs pulled in by HA), the latter has no secrets on a branch.

https://claude.ai/code/session_01R2RVM3N6RjLXT2qpEWNw3Y