### PR TITLE
Fix fan/relay stuck-on bugs in heater_cooler + fan mode transitions

### DIFF
--- a/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
@@ -147,8 +147,21 @@ class CoolerFanDevice(MultiHvacDevice):
             case _:
                 if self._hvac_mode is not None:
                     _LOGGER.warning("Invalid HVAC mode: %s", self._hvac_mode)
+                # Fail-safe: an unhandled/unmapped hvac_mode (e.g. this
+                # sub-device being left in a stale mode by a parent
+                # MultiHvacDevice that doesn't manage a mode it owns, such
+                # as HEAT) must not leave the cooler/fan relays energized
+                # indefinitely. See https://github.com/swingerman/ha-dual-smart-thermostat/issues/632
+                await self.async_turn_off_all(time=time)
+                self.HVACActionReason = HVACActionReason.NONE
 
     async def _async_control_when_fan_on_with_cooler(self, time=None, force=False):
+        # Fix for https://github.com/swingerman/ha-dual-smart-thermostat/issues/632:
+        # the fan sub-device's own hvac_mode must be set before delegating to
+        # its control loop, otherwise it has nothing to act on and silently
+        # leaves the fan in whatever state it was previously (often off, or
+        # stuck on from an unrelated prior fan_only selection).
+        self.fan_device.hvac_mode = HVACMode.FAN_ONLY
         await self.fan_device.async_control_hvac(time, force)
         await self.cooler_device.async_control_hvac(time, force)
         self.HVACActionReason = self.cooler_device.HVACActionReason

--- a/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
@@ -183,7 +183,12 @@ class MultiHvacDevice(HVACDevice, ControlableHVACDevice):
             if self.hvac_mode in device.hvac_modes:
                 await device.async_control_hvac(time, force)
                 self._hvac_action_reason = device.HVACActionReason
-            elif device.is_active:
+            else:
+                # Fix for https://github.com/swingerman/ha-dual-smart-thermostat/issues/632:
+                # unconditionally turn off sub-devices that don't handle the
+                # current top-level hvac_mode, instead of gating on their
+                # is_active cache (which can desync from the real switch
+                # state and leave a relay stuck energized).
                 await device.async_turn_off()
 
             # self._hvac_action_reason = device.HVACActionReason


### PR DESCRIPTION
## Summary
Fixes #632 — two related bugs where a `heater_cooler` system with a fan configured could leave the fan (or cooler) relay energized when it shouldn't be:

1. **`fan_on_with_ac` had no effect.** `_async_control_when_fan_on_with_cooler` in `cooler_fan_device.py` called `self.fan_device.async_control_hvac(...)` without ever setting `self.fan_device.hvac_mode` first, so the fan device had nothing to act on. It only appeared to "work" if the fan happened to already be on from an earlier `fan_only` selection — it wasn't actually reacting to the cooling call.

2. **A relay could stay stuck on when switching to a mode a sub-device doesn't handle** (e.g. plain `heat` on a `heater_cooler` + fan system). `MultiHvacDevice.async_control_hvac` only force-turned-off a non-matching sub-device when its `is_active` cache happened to be `True`, which can desync from the real switch state. Separately, `CoolerFanDevice.async_control_hvac`'s `match` statement had no fail-safe turn-off in its default case for an unhandled `hvac_mode`.

## Changes
- `cooler_fan_device.py`: set `self.fan_device.hvac_mode = HVACMode.FAN_ONLY` before delegating to the fan's control loop in `_async_control_when_fan_on_with_cooler`; added a fail-safe `async_turn_off_all()` in the `match` statement's default case instead of only logging a warning.
- `multi_hvac_device.py`: changed the non-matching sub-device branch from `elif device.is_active: await device.async_turn_off()` to an unconditional `else: await device.async_turn_off()`. `async_turn_off()` is idempotent on an already-off entity, so this is safe to call every control cycle regardless of the cached `is_active` state.

## Test plan
- [x] Reproduced both bugs against a live `heater_cooler` + fan setup (ESPHome relay switches) before patching
- [x] Confirmed `fan_on_with_ac: true` now turns the fan on alongside a fresh `off -> cool` transition
- [x] Confirmed switching `fan_only -> heat` now correctly turns the fan off instead of leaving it stuck on
- [ ] No existing automated tests were run — happy to add unit tests for these two code paths if useful, let me know the preferred style/location in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)