### PR TITLE
Fix reconfigure silently shadowed by stale entry.options

### DIFF
--- a/custom_components/dual_smart_thermostat/config_flow.py
+++ b/custom_components/dual_smart_thermostat/config_flow.py
@@ -842,6 +842,15 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             return self.async_update_reload_and_abort(
                 self._get_reconfigure_entry(),
                 data=cleaned_config,
+                # Fix for https://github.com/swingerman/ha-dual-smart-thermostat/issues/631:
+                # entry.options takes precedence over entry.data at runtime
+                # (see climate.py's {**data, **options} merge). If Options
+                # was ever saved previously, its frozen snapshot silently
+                # shadows every field reconfigure just updated in entry.data
+                # — including target_sensor — with no error shown. Clear the
+                # stale options so a successful reconfigure actually takes
+                # effect.
+                options={},
             )
         else:
             # Config flow: create new entry


### PR DESCRIPTION
## Summary
Fixes #631. Credit to the root-cause analysis already posted on that issue — this PR just implements the "minimal fix" suggested there.

`entry.options` takes precedence over `entry.data` at runtime (`climate.py` merges via `{**config_entry.data, **config_entry.options}`). Once the Options ("Configure") flow has been saved even once for an entry, it round-trips a full snapshot of the merged config back into `entry.options` — including fields like `target_sensor` that Options doesn't even present a form for. From that point on, `entry.options`'s frozen copy permanently shadows any later change made through Reconfigure, since Reconfigure only ever writes to `entry.data` and never touches `entry.options`. No error is shown anywhere in the flow — reconfigure reports success, the old value just silently keeps being used.

## Change
In `config_flow.py`'s `_async_finish_flow`, clear `entry.options` when completing a reconfigure, so a successful reconfigure can no longer be shadowed by a stale options snapshot:

```python
return self.async_update_reload_and_abort(
    self._get_reconfigure_entry(),
    data=cleaned_config,
    options={},
)
```

This is the minimal fix from the issue's root-cause writeup. The longer-term fix suggested there — having the Options flow only write back the specific keys it actually presents a form for, instead of round-tripping the entire merged config — is a bigger structural change I didn't attempt here, but happy to take a pass at it if that's the preferred direction instead.

## Test plan
- [ ] Repro steps from #631: set up `heater_cooler`, open Options once (e.g. tweak a tolerance), then Reconfigure and change `target_sensor` — confirm the new sensor is actually used afterward instead of being silently shadowed
- Not yet tested against a live instance the way #633 was — flagging this one is based on the issue's diagnosis rather than my own repro, so please double check before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)