### PR TITLE
Apply min_cycle_duration protection to fan, not just cooler

### DIFF
--- a/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/cooler_fan_device.py
@@ -170,10 +170,26 @@ class CoolerFanDevice(MultiHvacDevice):
         has_cooler_run_long_enough = (
             self.cooler_device.hvac_controller.ran_long_enough()
         )
+        has_fan_run_long_enough = self.fan_device.hvac_controller.ran_long_enough()
 
         if self.cooler_device.is_on and not has_cooler_run_long_enough:
             _LOGGER.debug(
                 "Cooler has not run long enough at: %s",
+                datetime.now(timezone.utc),
+            )
+            self.HVACActionReason = HVACActionReason.MIN_CYCLE_DURATION_NOT_REACHED
+            return
+
+        # Fix for https://github.com/swingerman/ha-dual-smart-thermostat/issues/385:
+        # the cooler above is protected from being switched off before its
+        # min_cycle_duration elapses, but the fan never was - so it could be
+        # flipped on then immediately back off every time cur_temp ticked
+        # across the fan-tolerance boundary. Apply the same protection here,
+        # symmetrically, before letting the temperature reading move us out
+        # of the fan-only branch.
+        if self.fan_device.is_on and not is_within_fan_tolerance and not has_fan_run_long_enough:
+            _LOGGER.debug(
+                "Fan has not run long enough at: %s",
                 datetime.now(timezone.utc),
             )
             self.HVACActionReason = HVACActionReason.MIN_CYCLE_DURATION_NOT_REACHED


### PR DESCRIPTION
## Summary
Fixes #385.

`_async_control_cooler` already refuses to turn the **cooler** off before `min_cycle_duration` elapses (`has_cooler_run_long_enough` check), but never applied the same protection to the **fan**. Since `is_within_fan_tolerance` is a single threshold rather than a hysteresis band, the current temperature ticking back and forth across it (the reporter's example: target 23.0°C, oscillating 23.0/22.9) flips the fan on then immediately back off on every poll, with nothing to debounce it — matches the reporter's "Desired behaviour B" request almost exactly, just using the `min_cycle_duration` option that already exists rather than adding a new config knob.

## Change
Added the same `hvac_controller.ran_long_enough()` guard for the fan that already exists for the cooler, applied symmetrically right after it: if the fan is on and we've just moved outside the tolerance band but the fan hasn't run for `min_cycle_duration` yet, hold off rather than switching it off immediately.

## Test plan
- [ ] Not yet reproduced/tested against a live instance — this is based on reading the control-loop logic (confirmed the missing symmetry) rather than reproducing the oscillation myself, so please verify before merging
- Existing `min_cycle_duration` config is reused, no new option added

🤖 Generated with [Claude Code](https://claude.com/claude-code)