### PR TITLE
fix: re-detect fan speed control when the fan entity appears late

### DIFF
--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -1797,6 +1797,17 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
         """Handle heater switch state changes."""
 
         data = event.data
+
+        # The fan entity may only now have turned up (issue #636). Notify the
+        # fan device directly rather than the whole tree: MultiHvacDevice's
+        # hook re-merges hvac_modes, which must not run on every switch event.
+        fan_device = self.features.fan_device
+        if fan_device is not None and data["new_state"] is not None:
+            had_fan_mode = fan_device.supports_fan_mode
+            fan_device.on_entity_state_changed(data["entity_id"], data["new_state"])
+            if fan_device.supports_fan_mode != had_fan_mode:
+                self._set_support_flags()
+
         self._async_switch_changed(data["old_state"], data["new_state"])
 
     @callback
@@ -1815,12 +1826,6 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
             # event loop, and create_task's call_soon_threadsafe defers the run
             # by a loop iteration, racing whatever the caller does next.
             self.hass.async_create_task(self._check_device_initial_state())
-
-        # A fan provided by an integration that connects asynchronously may
-        # only now have become available, so this is our chance to pick up the
-        # speed control we couldn't see at setup (issue #636).
-        if self.features.redetect_fan_capabilities():
-            self._set_support_flags()
 
         self.async_write_ha_state()
 

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -9,6 +9,7 @@ from typing import Any
 from homeassistant.components.climate import (
     PLATFORM_SCHEMA,
     ClimateEntity,
+    ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )
@@ -1798,15 +1799,16 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
 
         data = event.data
 
-        # The fan entity may only now have turned up (issue #636). Notify the
-        # fan device directly rather than the whole tree: MultiHvacDevice's
-        # hook re-merges hvac_modes, which must not run on every switch event.
+        # The fan entity may only now have turned up (issue #636). Only the
+        # FAN_MODE bit can have changed, so set it directly - a full
+        # _set_support_flags() would also reset target temps from presets.
         fan_device = self.features.fan_device
-        if fan_device is not None and data["new_state"] is not None:
-            had_fan_mode = fan_device.supports_fan_mode
-            fan_device.on_entity_state_changed(data["entity_id"], data["new_state"])
-            if fan_device.supports_fan_mode != had_fan_mode:
-                self._set_support_flags()
+        if (
+            fan_device is not None
+            and data["new_state"] is not None
+            and fan_device.redetect_capabilities(data["entity_id"], data["new_state"])
+        ):
+            self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
 
         self._async_switch_changed(data["old_state"], data["new_state"])
 

--- a/custom_components/dual_smart_thermostat/climate.py
+++ b/custom_components/dual_smart_thermostat/climate.py
@@ -1816,6 +1816,12 @@ class DualSmartThermostat(ClimateEntity, RestoreEntity):
             # by a loop iteration, racing whatever the caller does next.
             self.hass.async_create_task(self._check_device_initial_state())
 
+        # A fan provided by an integration that connects asynchronously may
+        # only now have become available, so this is our chance to pick up the
+        # speed control we couldn't see at setup (issue #636).
+        if self.features.redetect_fan_capabilities():
+            self._set_support_flags()
+
         self.async_write_ha_state()
 
         self._resume_from_state(old_state, new_state)

--- a/custom_components/dual_smart_thermostat/hvac_device/fan_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/fan_device.py
@@ -49,13 +49,12 @@ class FanDevice(CoolerDevice):
         self._fan_modes = []
         self._uses_preset_modes = False
         self._current_fan_mode = None
-        # Held until the entity turns up and detection succeeds (issue #636).
         self._pending_fan_mode = None
         self._detect_fan_capabilities()
 
-    def _detect_fan_capabilities(self) -> None:
+    def _detect_fan_capabilities(self, fan_state: State | None = None) -> None:
         """Detect if fan entity supports speed control."""
-        fan_state = self.hass.states.get(self.entity_id)
+        fan_state = fan_state or self.hass.states.get(self.entity_id)
 
         if not fan_state:
             _LOGGER.debug("Fan entity %s not found, no speed control", self.entity_id)
@@ -101,21 +100,22 @@ class FanDevice(CoolerDevice):
 
         _LOGGER.debug("Fan entity %s does not support speed control", self.entity_id)
 
-    # override
     @callback
-    def on_entity_state_changed(self, entity_id: str, new_state: State) -> None:
-        """Retry detection once our entity shows up (issue #636).
-
-        The fan may have had no state when the device was built.
-        """
+    def redetect_capabilities(self, entity_id: str, new_state: State) -> bool:
+        """Retry detection once our entity shows up, True if it gained speed control."""
         if entity_id != self.entity_id or self._supports_fan_mode:
-            return
+            return False
 
-        self._detect_fan_capabilities()
+        self._detect_fan_capabilities(new_state)
 
-        if self._supports_fan_mode and self._pending_fan_mode is not None:
+        if not self._supports_fan_mode:
+            return False
+
+        if self._pending_fan_mode is not None:
             self.restore_fan_mode(self._pending_fan_mode)
             self._pending_fan_mode = None
+
+        return True
 
     @property
     def supports_fan_mode(self) -> bool:
@@ -147,8 +147,7 @@ class FanDevice(CoolerDevice):
         fan device before restoring it. Invalid modes are logged and ignored.
         """
         if not self._supports_fan_mode:
-            # Entity isn't up yet; hold the mode for on_entity_state_changed
-            # rather than dropping it (issue #636).
+            # Entity isn't up yet; hold it for redetect_capabilities (issue #636).
             self._pending_fan_mode = fan_mode
             return
 

--- a/custom_components/dual_smart_thermostat/hvac_device/fan_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/fan_device.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 import logging
 
 from homeassistant.components.climate import HVACAction, HVACMode
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State, callback
 
 from ..const import FAN_MODE_TO_PERCENTAGE
 from ..hvac_device.cooler_device import CoolerDevice
@@ -49,6 +49,8 @@ class FanDevice(CoolerDevice):
         self._fan_modes = []
         self._uses_preset_modes = False
         self._current_fan_mode = None
+        # Held until the entity turns up and detection succeeds (issue #636).
+        self._pending_fan_mode = None
         self._detect_fan_capabilities()
 
     def _detect_fan_capabilities(self) -> None:
@@ -99,32 +101,21 @@ class FanDevice(CoolerDevice):
 
         _LOGGER.debug("Fan entity %s does not support speed control", self.entity_id)
 
-    def redetect_fan_capabilities(self) -> bool:
-        """Retry detection for a fan that wasn't ready when we were created.
+    # override
+    @callback
+    def on_entity_state_changed(self, entity_id: str, new_state: State) -> None:
+        """Retry detection once our entity shows up (issue #636).
 
-        Integrations that connect asynchronously (ESPHome, MQTT) often have
-        no state, or an unavailable one, at the moment the thermostat is set
-        up. Detection then finds nothing and the fan is left permanently
-        without speed control until the user reloads the integration
-        (issue #636). Called again whenever the fan entity's state changes.
-
-        Returns True only when this call is what discovered speed control,
-        so the caller knows it needs to refresh its supported features.
+        The fan may have had no state when the device was built.
         """
-        if self._supports_fan_mode:
-            return False
+        if entity_id != self.entity_id or self._supports_fan_mode:
+            return
 
         self._detect_fan_capabilities()
 
-        if self._supports_fan_mode:
-            _LOGGER.info(
-                "Fan entity %s became available and supports speed control: %s",
-                self.entity_id,
-                self._fan_modes,
-            )
-            return True
-
-        return False
+        if self._supports_fan_mode and self._pending_fan_mode is not None:
+            self.restore_fan_mode(self._pending_fan_mode)
+            self._pending_fan_mode = None
 
     @property
     def supports_fan_mode(self) -> bool:
@@ -155,6 +146,12 @@ class FanDevice(CoolerDevice):
         This method validates that the fan mode is valid for the current
         fan device before restoring it. Invalid modes are logged and ignored.
         """
+        if not self._supports_fan_mode:
+            # Entity isn't up yet; hold the mode for on_entity_state_changed
+            # rather than dropping it (issue #636).
+            self._pending_fan_mode = fan_mode
+            return
+
         if fan_mode in self._fan_modes:
             self._current_fan_mode = fan_mode
             _LOGGER.info("Restored fan mode %s for entity %s", fan_mode, self.entity_id)

--- a/custom_components/dual_smart_thermostat/hvac_device/fan_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/fan_device.py
@@ -99,6 +99,33 @@ class FanDevice(CoolerDevice):
 
         _LOGGER.debug("Fan entity %s does not support speed control", self.entity_id)
 
+    def redetect_fan_capabilities(self) -> bool:
+        """Retry detection for a fan that wasn't ready when we were created.
+
+        Integrations that connect asynchronously (ESPHome, MQTT) often have
+        no state, or an unavailable one, at the moment the thermostat is set
+        up. Detection then finds nothing and the fan is left permanently
+        without speed control until the user reloads the integration
+        (issue #636). Called again whenever the fan entity's state changes.
+
+        Returns True only when this call is what discovered speed control,
+        so the caller knows it needs to refresh its supported features.
+        """
+        if self._supports_fan_mode:
+            return False
+
+        self._detect_fan_capabilities()
+
+        if self._supports_fan_mode:
+            _LOGGER.info(
+                "Fan entity %s became available and supports speed control: %s",
+                self.entity_id,
+                self._fan_modes,
+            )
+            return True
+
+        return False
+
     @property
     def supports_fan_mode(self) -> bool:
         """Return if fan supports speed control."""

--- a/custom_components/dual_smart_thermostat/managers/feature_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/feature_manager.py
@@ -363,6 +363,16 @@ class FeatureManager(StateManager):
             return []
         return self._fan_device.fan_modes
 
+    def redetect_fan_capabilities(self) -> bool:
+        """Retry fan speed-control detection, returning True if it succeeded now.
+
+        See ``FanDevice.redetect_fan_capabilities`` - the fan entity may not
+        have existed when the device was built (issue #636).
+        """
+        if self._fan_device is None:
+            return False
+        return self._fan_device.redetect_fan_capabilities()
+
     def _restore_fan_mode(self, old_state: State) -> None:
         """Restore fan mode from old state."""
         if not self.supports_fan_mode:

--- a/custom_components/dual_smart_thermostat/managers/feature_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/feature_manager.py
@@ -363,24 +363,8 @@ class FeatureManager(StateManager):
             return []
         return self._fan_device.fan_modes
 
-    def redetect_fan_capabilities(self) -> bool:
-        """Retry fan speed-control detection, returning True if it succeeded now.
-
-        See ``FanDevice.redetect_fan_capabilities`` - the fan entity may not
-        have existed when the device was built (issue #636).
-        """
-        if self._fan_device is None:
-            return False
-        return self._fan_device.redetect_fan_capabilities()
-
     def _restore_fan_mode(self, old_state: State) -> None:
         """Restore fan mode from old state."""
-        if not self.supports_fan_mode:
-            _LOGGER.debug(
-                "Fan mode restoration skipped: device does not support speed control"
-            )
-            return
-
         if self._fan_device is None:
             _LOGGER.debug("Fan mode restoration skipped: no fan device")
             return

--- a/tests/test_fan_speed_control.py
+++ b/tests/test_fan_speed_control.py
@@ -182,10 +182,12 @@ async def test_fan_device_switch_no_speed_control(hass: HomeAssistant):
     assert fan_device.fan_modes == []
 
     # A switch can never gain speed control, so re-detection changes nothing.
-    fan_device.on_entity_state_changed(
-        "switch.test_fan", hass.states.get("switch.test_fan")
+    assert (
+        fan_device.redetect_capabilities(
+            "switch.test_fan", hass.states.get("switch.test_fan")
+        )
+        is False
     )
-    assert fan_device.supports_fan_mode is False
 
 
 @pytest.mark.asyncio
@@ -1865,34 +1867,6 @@ async def test_fan_activates_with_restored_fan_mode(hass: HomeAssistant):
 
 
 @pytest.mark.asyncio
-async def test_fan_capabilities_detected_when_entity_appears_late(hass: HomeAssistant):
-    """Speed control is picked up when the fan entity shows up after setup (#636)."""
-    fan_device = FanDevice(
-        hass,
-        "fan.late_fan",
-        timedelta(seconds=5),
-        HVACMode.FAN_ONLY,
-        MagicMock(spec=EnvironmentManager),
-        MagicMock(spec=OpeningManager),
-        MagicMock(spec=FeatureManager),
-        MagicMock(spec=HvacPowerManager),
-    )
-
-    assert fan_device.supports_fan_mode is False
-
-    # Entity appears
-    hass.states.async_set(
-        "fan.late_fan",
-        "off",
-        {"preset_modes": ["quiet", "boost"], "preset_mode": "quiet"},
-    )
-    fan_device.on_entity_state_changed("fan.late_fan", hass.states.get("fan.late_fan"))
-
-    assert fan_device.supports_fan_mode is True
-    assert fan_device.fan_modes == ["quiet", "boost"]
-
-
-@pytest.mark.asyncio
 async def test_late_fan_ignores_other_entities(hass: HomeAssistant):
     """Only the fan's own entity triggers detection (#636)."""
     fan_device = FanDevice(
@@ -1909,8 +1883,12 @@ async def test_late_fan_ignores_other_entities(hass: HomeAssistant):
     hass.states.async_set(
         "fan.late_fan", "off", {"preset_modes": ["quiet"], "preset_mode": "quiet"}
     )
-    fan_device.on_entity_state_changed("switch.heater", hass.states.get("fan.late_fan"))
-
+    assert (
+        fan_device.redetect_capabilities(
+            "switch.heater", hass.states.get("fan.late_fan")
+        )
+        is False
+    )
     assert fan_device.supports_fan_mode is False
 
 
@@ -1937,8 +1915,14 @@ async def test_restored_fan_mode_applied_when_entity_appears_late(hass: HomeAssi
         "off",
         {"preset_modes": ["quiet", "boost"], "preset_mode": "quiet"},
     )
-    fan_device.on_entity_state_changed("fan.late_fan", hass.states.get("fan.late_fan"))
+    assert (
+        fan_device.redetect_capabilities(
+            "fan.late_fan", hass.states.get("fan.late_fan")
+        )
+        is True
+    )
 
+    assert fan_device.fan_modes == ["quiet", "boost"]
     assert fan_device.current_fan_mode == "boost"
 
 

--- a/tests/test_fan_speed_control.py
+++ b/tests/test_fan_speed_control.py
@@ -181,6 +181,12 @@ async def test_fan_device_switch_no_speed_control(hass: HomeAssistant):
     assert fan_device.supports_fan_mode is False
     assert fan_device.fan_modes == []
 
+    # A switch can never gain speed control, so re-detection changes nothing.
+    fan_device.on_entity_state_changed(
+        "switch.test_fan", hass.states.get("switch.test_fan")
+    )
+    assert fan_device.supports_fan_mode is False
+
 
 @pytest.mark.asyncio
 async def test_fan_device_missing_entity_no_speed_control(hass: HomeAssistant):
@@ -1859,84 +1865,89 @@ async def test_fan_activates_with_restored_fan_mode(hass: HomeAssistant):
 
 
 @pytest.mark.asyncio
-async def test_fan_capabilities_redetected_when_entity_appears_late(
-    hass: HomeAssistant,
-):
-    """Fan speed control is picked up when the fan entity shows up after setup.
-
-    Issue #636: integrations that connect asynchronously (ESPHome, MQTT) have
-    no state yet when the thermostat is built, so detection found nothing and
-    speed control stayed unavailable until the user reloaded the integration.
-    """
-    environment = MagicMock(spec=EnvironmentManager)
-    openings = MagicMock(spec=OpeningManager)
-    features = MagicMock(spec=FeatureManager)
-    hvac_power = MagicMock(spec=HvacPowerManager)
-
-    # Entity does not exist yet, exactly as during an async integration's setup
+async def test_fan_capabilities_detected_when_entity_appears_late(hass: HomeAssistant):
+    """Speed control is picked up when the fan entity shows up after setup (#636)."""
     fan_device = FanDevice(
         hass,
         "fan.late_fan",
         timedelta(seconds=5),
         HVACMode.FAN_ONLY,
-        environment,
-        openings,
-        features,
-        hvac_power,
+        MagicMock(spec=EnvironmentManager),
+        MagicMock(spec=OpeningManager),
+        MagicMock(spec=FeatureManager),
+        MagicMock(spec=HvacPowerManager),
     )
 
     assert fan_device.supports_fan_mode is False
-    assert fan_device.fan_modes == []
 
-    # The integration finishes connecting and the entity materialises
+    # Entity appears
     hass.states.async_set(
         "fan.late_fan",
         "off",
         {"preset_modes": ["quiet", "boost"], "preset_mode": "quiet"},
     )
-    await hass.async_block_till_done()
+    fan_device.on_entity_state_changed("fan.late_fan", hass.states.get("fan.late_fan"))
 
-    assert fan_device.redetect_fan_capabilities() is True
     assert fan_device.supports_fan_mode is True
-    assert fan_device.fan_modes == ["quiet", "boost"]
-
-    # Already detected, so a later call reports no change and stays stable
-    assert fan_device.redetect_fan_capabilities() is False
     assert fan_device.fan_modes == ["quiet", "boost"]
 
 
 @pytest.mark.asyncio
-async def test_fan_capabilities_not_redetected_for_switch(hass: HomeAssistant):
-    """A switch-domain fan still gets no speed control on re-detection."""
-    environment = MagicMock(spec=EnvironmentManager)
-    openings = MagicMock(spec=OpeningManager)
-    features = MagicMock(spec=FeatureManager)
-    hvac_power = MagicMock(spec=HvacPowerManager)
-
+async def test_late_fan_ignores_other_entities(hass: HomeAssistant):
+    """Only the fan's own entity triggers detection (#636)."""
     fan_device = FanDevice(
         hass,
-        "switch.late_fan",
+        "fan.late_fan",
         timedelta(seconds=5),
         HVACMode.FAN_ONLY,
-        environment,
-        openings,
-        features,
-        hvac_power,
+        MagicMock(spec=EnvironmentManager),
+        MagicMock(spec=OpeningManager),
+        MagicMock(spec=FeatureManager),
+        MagicMock(spec=HvacPowerManager),
     )
 
-    hass.states.async_set("switch.late_fan", "off")
-    await hass.async_block_till_done()
+    hass.states.async_set(
+        "fan.late_fan", "off", {"preset_modes": ["quiet"], "preset_mode": "quiet"}
+    )
+    fan_device.on_entity_state_changed("switch.heater", hass.states.get("fan.late_fan"))
 
-    assert fan_device.redetect_fan_capabilities() is False
     assert fan_device.supports_fan_mode is False
+
+
+@pytest.mark.asyncio
+async def test_restored_fan_mode_applied_when_entity_appears_late(hass: HomeAssistant):
+    """A mode restored before the entity existed is applied once it does (#636)."""
+    fan_device = FanDevice(
+        hass,
+        "fan.late_fan",
+        timedelta(seconds=5),
+        HVACMode.FAN_ONLY,
+        MagicMock(spec=EnvironmentManager),
+        MagicMock(spec=OpeningManager),
+        MagicMock(spec=FeatureManager),
+        MagicMock(spec=HvacPowerManager),
+    )
+
+    # Restore runs at startup, before the entity is available
+    fan_device.restore_fan_mode("boost")
+    assert fan_device.current_fan_mode is None
+
+    hass.states.async_set(
+        "fan.late_fan",
+        "off",
+        {"preset_modes": ["quiet", "boost"], "preset_mode": "quiet"},
+    )
+    fan_device.on_entity_state_changed("fan.late_fan", hass.states.get("fan.late_fan"))
+
+    assert fan_device.current_fan_mode == "boost"
 
 
 @pytest.mark.asyncio
 async def test_climate_gains_fan_mode_when_fan_entity_appears_late(
     hass: HomeAssistant,
 ):
-    """End-to-end of issue #636: fan_modes appear without an integration reload."""
-    from homeassistant.components import input_boolean, input_number
+    """End-to-end of #636: fan_modes appear without an integration reload."""
+    from homeassistant.components import input_boolean
     from homeassistant.components.climate.const import (
         DOMAIN as CLIMATE,
         ClimateEntityFeature,
@@ -1953,17 +1964,8 @@ async def test_climate_gains_fan_mode_when_fan_entity_appears_late(
     assert await async_setup_component(
         hass, input_boolean.DOMAIN, {"input_boolean": {"test": None}}
     )
-    assert await async_setup_component(
-        hass,
-        input_number.DOMAIN,
-        {
-            "input_number": {
-                "temp": {"name": "test", "initial": 10, "min": 0, "max": 40, "step": 1}
-            }
-        },
-    )
 
-    # Deliberately do NOT create fan.late_fan before setting up the thermostat
+    # Deliberately do not create fan.late_fan before setting up the thermostat
     assert await async_setup_component(
         hass,
         CLIMATE,
@@ -1981,13 +1983,10 @@ async def test_climate_gains_fan_mode_when_fan_entity_appears_late(
     await hass.async_block_till_done()
 
     state = hass.states.get("climate.test")
-    assert state is not None
     assert not (
         state.attributes.get("supported_features") & ClimateEntityFeature.FAN_MODE
     )
-    assert state.attributes.get("fan_modes") is None
 
-    # The ESPHome/MQTT fan finishes connecting
     hass.states.async_set(
         "fan.late_fan",
         "off",

--- a/tests/test_fan_speed_control.py
+++ b/tests/test_fan_speed_control.py
@@ -1856,3 +1856,145 @@ async def test_fan_activates_with_restored_fan_mode(hass: HomeAssistant):
     # Should have set fan mode to "high"
     if len(preset_mode_calls) > 0:
         assert any(call.data.get("preset_mode") == "high" for call in preset_mode_calls)
+
+
+@pytest.mark.asyncio
+async def test_fan_capabilities_redetected_when_entity_appears_late(
+    hass: HomeAssistant,
+):
+    """Fan speed control is picked up when the fan entity shows up after setup.
+
+    Issue #636: integrations that connect asynchronously (ESPHome, MQTT) have
+    no state yet when the thermostat is built, so detection found nothing and
+    speed control stayed unavailable until the user reloaded the integration.
+    """
+    environment = MagicMock(spec=EnvironmentManager)
+    openings = MagicMock(spec=OpeningManager)
+    features = MagicMock(spec=FeatureManager)
+    hvac_power = MagicMock(spec=HvacPowerManager)
+
+    # Entity does not exist yet, exactly as during an async integration's setup
+    fan_device = FanDevice(
+        hass,
+        "fan.late_fan",
+        timedelta(seconds=5),
+        HVACMode.FAN_ONLY,
+        environment,
+        openings,
+        features,
+        hvac_power,
+    )
+
+    assert fan_device.supports_fan_mode is False
+    assert fan_device.fan_modes == []
+
+    # The integration finishes connecting and the entity materialises
+    hass.states.async_set(
+        "fan.late_fan",
+        "off",
+        {"preset_modes": ["quiet", "boost"], "preset_mode": "quiet"},
+    )
+    await hass.async_block_till_done()
+
+    assert fan_device.redetect_fan_capabilities() is True
+    assert fan_device.supports_fan_mode is True
+    assert fan_device.fan_modes == ["quiet", "boost"]
+
+    # Already detected, so a later call reports no change and stays stable
+    assert fan_device.redetect_fan_capabilities() is False
+    assert fan_device.fan_modes == ["quiet", "boost"]
+
+
+@pytest.mark.asyncio
+async def test_fan_capabilities_not_redetected_for_switch(hass: HomeAssistant):
+    """A switch-domain fan still gets no speed control on re-detection."""
+    environment = MagicMock(spec=EnvironmentManager)
+    openings = MagicMock(spec=OpeningManager)
+    features = MagicMock(spec=FeatureManager)
+    hvac_power = MagicMock(spec=HvacPowerManager)
+
+    fan_device = FanDevice(
+        hass,
+        "switch.late_fan",
+        timedelta(seconds=5),
+        HVACMode.FAN_ONLY,
+        environment,
+        openings,
+        features,
+        hvac_power,
+    )
+
+    hass.states.async_set("switch.late_fan", "off")
+    await hass.async_block_till_done()
+
+    assert fan_device.redetect_fan_capabilities() is False
+    assert fan_device.supports_fan_mode is False
+
+
+@pytest.mark.asyncio
+async def test_climate_gains_fan_mode_when_fan_entity_appears_late(
+    hass: HomeAssistant,
+):
+    """End-to-end of issue #636: fan_modes appear without an integration reload."""
+    from homeassistant.components import input_boolean, input_number
+    from homeassistant.components.climate.const import (
+        DOMAIN as CLIMATE,
+        ClimateEntityFeature,
+    )
+    from homeassistant.setup import async_setup_component
+    from homeassistant.util.unit_system import METRIC_SYSTEM
+
+    from custom_components.dual_smart_thermostat.const import DOMAIN
+
+    from . import common
+
+    hass.config.units = METRIC_SYSTEM
+
+    assert await async_setup_component(
+        hass, input_boolean.DOMAIN, {"input_boolean": {"test": None}}
+    )
+    assert await async_setup_component(
+        hass,
+        input_number.DOMAIN,
+        {
+            "input_number": {
+                "temp": {"name": "test", "initial": 10, "min": 0, "max": 40, "step": 1}
+            }
+        },
+    )
+
+    # Deliberately do NOT create fan.late_fan before setting up the thermostat
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "heater": "input_boolean.test",
+                "target_sensor": common.ENT_SENSOR,
+                "fan": "fan.late_fan",
+                "initial_hvac_mode": HVACMode.HEAT,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.test")
+    assert state is not None
+    assert not (
+        state.attributes.get("supported_features") & ClimateEntityFeature.FAN_MODE
+    )
+    assert state.attributes.get("fan_modes") is None
+
+    # The ESPHome/MQTT fan finishes connecting
+    hass.states.async_set(
+        "fan.late_fan",
+        "off",
+        {"preset_modes": ["quiet", "boost"], "preset_mode": "quiet"},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.test")
+    assert state.attributes.get("supported_features") & ClimateEntityFeature.FAN_MODE
+    assert set(state.attributes.get("fan_modes")) == {"quiet", "boost"}


### PR DESCRIPTION
Fixes #636.

## Problem

`FanDevice` detects speed control exactly once, in `__init__`, from the fan entity's state. That runs inside `HVACDeviceFactory.create_device()` during platform setup, so an integration that connects asynchronously — ESPHome in the report, MQTT behaves the same — has no state yet and detection finds nothing. There is no retry, so the thermostat is stuck with `fan_modes: None` and no `ClimateEntityFeature.FAN_MODE` until the user manually reloads, every restart.

## Fix

`FanDevice.redetect_capabilities(entity_id, new_state)` retries detection when the fan's own entity turns up, and returns whether speed control was gained. `climate.py` calls it from `_async_switch_changed_event`, which is already subscribed to every id in `hvac_device.get_device_ids()` — the fan included — so no new listener is needed.

Three deliberate choices, each of which I tried the other way first:

- **The fan device is called directly**, not through `hvac_device`. Routing through the tree reaches `MultiHvacDevice.on_entity_state_changed`, which re-merges `hvac_modes` and carries the #597 mode re-sync; running that on every switch event fails 21 `test_dual_mode.py` tests.
- **It is a named method, not an `on_entity_state_changed` override.** That shared hook is meant to be fanned out by the device tree, and since that route is unusable here, overriding it meant calling a tree hook directly on a single device — a third calling convention on an already-overloaded mechanism.
- **Only the `FAN_MODE` bit is set**, rather than calling `_set_support_flags()`. That helper is not a flag refresh — it also runs `set_default_target_temps` / `set_default_target_humidity`. A later real `_set_support_flags()` recomputes the bit anyway. I could not construct a config where the broader call actually disturbed a setpoint, so this is a narrowing on principle rather than a fix for an observed bug.

The reporter suggested `async_on_startup`. That still runs during setup, which for a device connecting seconds or minutes after HA starts is often *still* too early; hooking the state change covers whenever it actually arrives.

## Also fixed: the restored fan mode

`FeatureManager._restore_fan_mode()` bailed when `supports_fan_mode` was false, so a fan mode persisted across a restart was **dropped** whenever the entity arrived late — the fan came back at the detection default rather than the user's setting. `restore_fan_mode()` now holds the mode and applies it once detection succeeds.

## Tests

Three in `tests/test_fan_speed_control.py`, plus the switch-domain case folded into the existing `test_fan_device_switch_no_speed_control`. The end-to-end one mirrors the report: set the thermostat up with the fan entity absent, assert `FAN_MODE` is missing, create the entity, assert `fan_modes` and `FAN_MODE` appear with no reload.

Three of the four fail against `master`; the fourth asserts a negative, so it passes either way. Full suite: **1538 passed, 2 skipped**. Lint clean.

`dependency-audit` is red for reasons unrelated to this PR — it fails on `master` too (pillow/protobuf CVEs pulled in by HA).

https://claude.ai/code/session_01R2RVM3N6RjLXT2qpEWNw3Y
