### PR TITLE
fix: make fan_on_with_heater work when a cooler is configured

### DIFF
--- a/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/controllable_hvac_device.py
@@ -114,6 +114,17 @@ class ControlableHVACDevice(ABC):
     def HVACActionReason(self, hvac_action_reason: HVACActionReason):
         self._hvac_action_reason = hvac_action_reason
 
+    async def async_turn_off_unless_used(self, in_use: set[str]) -> None:
+        """Turn off, unless an entity we own is in use by the active device.
+
+        Wrappers can share an actuator - a heater wrapper and a cooler wrapper
+        may hold the same fan - so stopping a wrapper wholesale would switch
+        off an entity the running mode still needs (#637).
+        """
+        if set(self.get_device_ids()) & in_use:
+            return
+        await self.async_turn_off()
+
     def reset_hvac_action_reason(self) -> None:
         """Forget why the device last acted.
 

--- a/custom_components/dual_smart_thermostat/hvac_device/hvac_device_factory.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/hvac_device_factory.py
@@ -197,6 +197,26 @@ class HVACDeviceFactory:
                 self._features,
             )
 
+        # Combine the heater/heat pump with a fan into a dedicated cooperative
+        # device (mirrors CoolerFanDevice), so the fan can run alongside the
+        # heater when fan_on_with_heater is enabled (#622). With a cooler
+        # configured the fan already belongs to CoolerFanDevice, so only take
+        # it over when the user opted in - otherwise fan_on_with_heater has no
+        # effect on heater+cooler systems (#637).
+        if heater_device is not None and fan_device is not None:
+            if (
+                cooler_device is None
+                or self._features.is_configured_for_fan_on_with_heater
+            ):
+                heater_device = HeaterFanDevice(
+                    self.hass,
+                    [heater_device, fan_device],
+                    self._initial_hvac_mode,
+                    environment,
+                    openings,
+                    self._features,
+                )
+
         _LOGGER.debug(
             "heater_device: %s, cooler_device: %s", heater_device, cooler_device
         )
@@ -230,18 +250,6 @@ class HVACDeviceFactory:
                 return heater_cooler_device
 
         if heater_device:
-            # Combine the heater/heat pump with a fan into a dedicated
-            # cooperative device (mirrors CoolerFanDevice). The fan runs
-            # alongside the heater when fan_on_with_heater is enabled (#622).
-            if fan_device:
-                heater_device = HeaterFanDevice(
-                    self.hass,
-                    [heater_device, fan_device],
-                    self._initial_hvac_mode,
-                    environment,
-                    openings,
-                    self._features,
-                )
             sub_devices = [heater_device]
             if dryer_device:
                 sub_devices.append(dryer_device)

--- a/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
+++ b/custom_components/dual_smart_thermostat/hvac_device/multi_hvac_device.py
@@ -53,6 +53,12 @@ class MultiHvacDevice(HVACDevice, ControlableHVACDevice):
         for device in self.hvac_devices:
             device.reset_hvac_action_reason()
 
+    # override
+    async def async_turn_off_unless_used(self, in_use: set[str]) -> None:
+        """Push the check down to the sub-devices so shared ones are spared."""
+        for device in self.hvac_devices:
+            await device.async_turn_off_unless_used(in_use)
+
     @callback
     def on_entity_state_changed(self, entity_id: str, new_state: State) -> None:
         """Forward state-change notifications to every sub-device.
@@ -179,14 +185,25 @@ class MultiHvacDevice(HVACDevice, ControlableHVACDevice):
             _LOGGER.warning("Invalid HVAC mode: %s", self._hvac_mode)
             return
 
+        # Stop the devices that do not handle this mode before running the one
+        # that does, and spare any entity the handling device also owns: a
+        # heater wrapper and a cooler wrapper may hold the same fan, and
+        # stopping one would switch that fan off (#637).
+        in_use = {
+            entity_id
+            for device in self.hvac_devices
+            if self.hvac_mode in device.hvac_modes
+            for entity_id in device.get_device_ids()
+        }
+
+        for device in self.hvac_devices:
+            if self.hvac_mode not in device.hvac_modes and device.is_active:
+                await device.async_turn_off_unless_used(in_use)
+
         for device in self.hvac_devices:
             if self.hvac_mode in device.hvac_modes:
                 await device.async_control_hvac(time, force)
                 self._hvac_action_reason = device.HVACActionReason
-            elif device.is_active:
-                await device.async_turn_off()
-
-            # self._hvac_action_reason = device.HVACActionReason
 
     async def async_on_startup(self, async_write_ha_state_cb: Callable = None):
         self._async_write_ha_state_cb = async_write_ha_state_cb

--- a/tests/test_heater_mode.py
+++ b/tests/test_heater_mode.py
@@ -3085,3 +3085,163 @@ async def test_aux_heater_dual_mode_heat_cool_mode_both_stay_on(
 
     assert hass.states.get(heater_switch).state == STATE_OFF
     assert hass.states.get(secondary_heater_switch).state == STATE_OFF
+
+
+async def test_heater_cooler_with_fan_keeps_fan_running_while_heating(
+    hass: HomeAssistant, setup_comp_1  # noqa: F811
+) -> None:
+    """fan_on_with_heater must work when a cooler is configured too.
+
+    Regression test for issue #637: with heater + cooler + fan and
+    ``fan_on_with_heater`` enabled, the fan never ran in HEAT. The factory only
+    wrapped the heater in HeaterFanDevice on the heater-only path, and the
+    cooler's wrapper - which shares the same fan device - turned the fan back
+    off on every control cycle.
+    """
+    from . import setup_switch_dual
+
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": common.ENT_SWITCH,
+                "cooler": common.ENT_COOLER,
+                "fan": common.ENT_FAN,
+                "fan_on_with_ac": True,
+                "fan_on_with_heater": True,
+                "heat_cool_mode": False,
+                "target_sensor": common.ENT_SENSOR,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await common.async_set_temperature(hass, 26)
+    setup_sensor(hass, 23)  # below target -> should heat
+
+    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
+
+    await common.async_set_hvac_mode(hass, HVACMode.HEAT)
+    await hass.async_block_till_done()
+
+    heater_on = [
+        c
+        for c in calls
+        if c.service == SERVICE_TURN_ON and c.data.get("entity_id") == common.ENT_SWITCH
+    ]
+    fan_on = [
+        c
+        for c in calls
+        if c.service == SERVICE_TURN_ON and c.data.get("entity_id") == common.ENT_FAN
+    ]
+    fan_off = [
+        c
+        for c in calls
+        if c.service == SERVICE_TURN_OFF and c.data.get("entity_id") == common.ENT_FAN
+    ]
+    assert len(heater_on) >= 1, f"heater should be heating, got: {calls}"
+    assert len(fan_on) >= 1, f"fan should run while heating, got: {calls}"
+    assert len(fan_off) == 0, f"fan must not be turned off while heating, got: {calls}"
+
+
+async def test_heater_cooler_with_fan_does_not_turn_off_running_fan(
+    hass: HomeAssistant, setup_comp_1  # noqa: F811
+) -> None:
+    """The cooler's wrapper must not switch off the fan the heater is using.
+
+    Second half of issue #637: heater and cooler each wrap the *same* fan
+    device, so on every control cycle the cooler wrapper - which does not
+    handle HEAT - saw the running fan as its own and turned it off again.
+    """
+    from . import setup_switch_dual
+
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": common.ENT_SWITCH,
+                "cooler": common.ENT_COOLER,
+                "fan": common.ENT_FAN,
+                "fan_on_with_ac": True,
+                "fan_on_with_heater": True,
+                "heat_cool_mode": False,
+                "target_sensor": common.ENT_SENSOR,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await common.async_set_temperature(hass, 26)
+    setup_sensor(hass, 23)
+    await common.async_set_hvac_mode(hass, HVACMode.HEAT)
+    await hass.async_block_till_done()
+
+    # Heater and fan are genuinely running, as they would be on real hardware
+    calls = setup_switch_dual(hass, common.ENT_FAN, True, True)
+    await hass.async_block_till_done()
+
+    # A routine temperature update while still below target
+    setup_sensor(hass, 24)
+    await hass.async_block_till_done()
+
+    fan_off = [
+        c
+        for c in calls
+        if c.service == SERVICE_TURN_OFF and c.data.get("entity_id") == common.ENT_FAN
+    ]
+    assert len(fan_off) == 0, f"running fan must not be switched off, got: {calls}"
+
+
+async def test_heater_cooler_with_fan_off_with_heater_keeps_legacy_behavior(
+    hass: HomeAssistant, setup_comp_1  # noqa: F811
+) -> None:
+    """Without ``fan_on_with_heater`` a heater+cooler+fan config is unchanged.
+
+    Gating guard for #637: the heater only takes the fan over when the user
+    opted in, otherwise the fan stays with the cooler as before.
+    """
+    from . import setup_switch_dual
+
+    assert await async_setup_component(
+        hass,
+        CLIMATE,
+        {
+            "climate": {
+                "platform": DOMAIN,
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": common.ENT_SWITCH,
+                "cooler": common.ENT_COOLER,
+                "fan": common.ENT_FAN,
+                "heat_cool_mode": False,
+                "target_sensor": common.ENT_SENSOR,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await common.async_set_temperature(hass, 26)
+    setup_sensor(hass, 23)
+
+    calls = setup_switch_dual(hass, common.ENT_FAN, False, False)
+
+    await common.async_set_hvac_mode(hass, HVACMode.HEAT)
+    await hass.async_block_till_done()
+
+    fan_on = [
+        c
+        for c in calls
+        if c.service == SERVICE_TURN_ON and c.data.get("entity_id") == common.ENT_FAN
+    ]
+    assert len(fan_on) == 0, f"fan must stay off without opt-in, got: {calls}"


### PR DESCRIPTION
Fixes #637.

Two separate faults, both only reachable when heater, cooler and fan are configured together — which is why the #622 tests (heat pump + fan, no cooler) never caught them. @pantelisdotzip's report nailed both symptoms.

## 1. The fan was never wired to the heater

`HVACDeviceFactory` only wrapped the heater in `HeaterFanDevice` on the heater-only path:

```python
if heater_device is not None and cooler_device is not None:
    heater_cooler_device = HeaterCoolerDevice([heater_device, cooler_device], ...)   # unwrapped heater
    ...
    return heater_cooler_device

if heater_device:
    if fan_device:
        heater_device = HeaterFanDevice([heater_device, fan_device], ...)   # never reached
```

With a cooler configured the first branch returns, so `fan_on_with_heater` was dead config for those systems.

The wrap now happens before both branches. With a cooler present it only takes the fan over when the user opted in — otherwise the fan stays with `CoolerFanDevice` exactly as before.

## 2. The running fan was switched off again

The heater and cooler wrappers hold the **same** `FanDevice`. In HEAT, the cooler wrapper looked active — `MultiHvacDevice.is_active` is `any(sub.is_active)` and its share of the fan was on — so the parent stopped it, taking the fan down with it. That is the reporter's *"if I start the fan manually it is switched off in the next temperature change"*.

`MultiHvacDevice.async_control_hvac` now stops the devices that do not handle the mode **before** running the one that does, and spares any entity the handling device also owns, through a new `async_turn_off_unless_used(in_use)` on `ControlableHVACDevice` (overridden by `MultiHvacDevice` to push the check down to sub-devices).

Ordering alone was not enough — I tried it. The end state was right, but the fan still got a spurious off/on every control cycle, which is relay chatter on real hardware. Sparing the shared entity is what actually fixes it.

## Tests

Three in `tests/test_heater_mode.py`:

- **fault 1** — heater + cooler + fan with `fan_on_with_heater`: the fan must run in HEAT
- **fault 2** — same config with the fan switch **genuinely on**: no `turn_off` on a routine temperature update. This needs a separate test because the service mocks never flip entity state, so fault 2 is invisible in the first one — and fault 1 is invisible once fault 2 is fixed
- **opt-out guard** — without `fan_on_with_heater`, the fan stays off in HEAT, so existing configs are unchanged

The first two fail against `master`; the third passes either way by design.

Full suite: **1541 passed, 2 skipped**. Lint clean.

## Note for #633

This touches `MultiHvacDevice.async_control_hvac`, the same method as #633. The conflict is small, but worth knowing about — and #633's proposed unconditional `else: await device.async_turn_off()` would make fault 2 strictly worse, since it removes the `is_active` gate that currently limits how often the shared fan gets stopped.
