### PR TITLE
fix: stop re-applying a preset from restoring the other mode's setpoint

### DIFF
--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -918,16 +918,19 @@ class EnvironmentManager(StateManager):
                     preset_temp_high is not None
                 ):
                     _LOGGER.debug(
-                        "Setting temperatures from preset range mode if HVACMode.COOL, HVACMode.FAN_ONLY. Preset: %s, sved_target_temp: %s",
+                        "Setting temperatures from preset range mode if HVACMode.COOL, HVACMode.FAN_ONLY. Preset: %s",
                         preset_temp_high,
-                        self._saved_target_temp,
                     )
-                    preset_match_old = old_preset_mode == preset_mode
-                    self._target_temp = (
-                        self._saved_target_temp
-                        if preset_match_old and self._saved_target_temp
-                        else preset_temp_high
-                    )
+                    # Always the preset's own high value, mirroring the HEAT
+                    # branch above. This used to prefer _saved_target_temp when
+                    # the preset name was unchanged, but that value is not
+                    # mode-scoped - it can hold a setpoint captured while the
+                    # opposite mode was active, so re-applying the active preset
+                    # after heat -> cool made the thermostat cool toward its heat
+                    # setpoint (issue #641). Restart restore does not rely on
+                    # this: it skips this method entirely (is_restore) and
+                    # applies the persisted temperature directly.
+                    self._target_temp = preset_temp_high
                 else:
                     _LOGGER.debug("Setting target temp from preset, unhandled case")
 

--- a/custom_components/dual_smart_thermostat/managers/environment_manager.py
+++ b/custom_components/dual_smart_thermostat/managers/environment_manager.py
@@ -799,11 +799,9 @@ class EnvironmentManager(StateManager):
             self._set_floor_temp_limits_from_config()
         else:
             self._set_temps_when_have_preset_mode(
-                preset_mode,
                 preset_env,
                 hvac_mode,
                 is_range_mode,
-                old_preset_mode,
             )
             self._set_floor_temp_limits_from_preset(preset_env)
 
@@ -831,13 +829,22 @@ class EnvironmentManager(StateManager):
                 hvac_mode, supports_temp_range, old_preset_mode
             )
 
+    @staticmethod
+    def _bound_for_mode(
+        hvac_mode: HVACMode, low: float | None, high: float | None
+    ) -> float | None:
+        """Which of a low/high pair a single-setpoint thermostat targets in this mode."""
+        if hvac_mode == HVACMode.HEAT:
+            return low
+        if hvac_mode in (HVACMode.COOL, HVACMode.FAN_ONLY):
+            return high
+        return None
+
     def _set_temps_when_have_preset_mode(
         self,
-        preset_mode: str,
         preset_env: PresetEnv | None,
         hvac_mode: HVACMode,
         is_range_mode: bool,
-        old_preset_mode: str | None = None,
     ) -> None:
         _LOGGER.debug(
             "Setting temperatures from hvac mode and presets when have preset mode. is_range_mode: %s",
@@ -907,30 +914,19 @@ class EnvironmentManager(StateManager):
                     preset_env,
                 )
 
-                if hvac_mode == HVACMode.HEAT:
-                    if preset_temp_low is not None:
-                        _LOGGER.debug(
-                            "Setting temperatures from preset range mode if HVACMode.HEAT. Preset: %s",
-                            preset_temp_low,
-                        )
-                        self._target_temp = preset_temp_low
-                elif hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY] and (
-                    preset_temp_high is not None
-                ):
+                # The preset's own bound for this mode, never _saved_target_temp:
+                # that value is not mode-scoped, so preferring it made a
+                # re-applied preset cool toward the heat setpoint (#641).
+                bound = self._bound_for_mode(
+                    hvac_mode, preset_temp_low, preset_temp_high
+                )
+                if bound is not None:
                     _LOGGER.debug(
-                        "Setting temperatures from preset range mode if HVACMode.COOL, HVACMode.FAN_ONLY. Preset: %s",
-                        preset_temp_high,
+                        "Setting target temp from preset range for %s: %s",
+                        hvac_mode,
+                        bound,
                     )
-                    # Always the preset's own high value, mirroring the HEAT
-                    # branch above. This used to prefer _saved_target_temp when
-                    # the preset name was unchanged, but that value is not
-                    # mode-scoped - it can hold a setpoint captured while the
-                    # opposite mode was active, so re-applying the active preset
-                    # after heat -> cool made the thermostat cool toward its heat
-                    # setpoint (issue #641). Restart restore does not rely on
-                    # this: it skips this method entirely (is_restore) and
-                    # applies the persisted temperature directly.
-                    self._target_temp = preset_temp_high
+                    self._target_temp = bound
                 else:
                     _LOGGER.debug("Setting target temp from preset, unhandled case")
 
@@ -971,35 +967,42 @@ class EnvironmentManager(StateManager):
         supports_temp_range: bool,
         old_preset_mode: str | None,
     ) -> None:
-        if (
-            old_preset_mode is not PRESET_NONE
-            and old_preset_mode is not None
-            and self.saved_target_temp is not None
-        ):
+        leaving_preset = (
+            old_preset_mode is not PRESET_NONE and old_preset_mode is not None
+        )
+        mode_bound = (
+            self._bound_for_mode(hvac_mode, self.target_temp_low, self.target_temp_high)
+            if supports_temp_range
+            else None
+        )
+
+        # This mode's own bound outranks saved_target_temp, which is not
+        # mode-scoped: after heat -> cool it still holds the heat setpoint, so
+        # leaving a preset used to resume cooling toward it (#641).
+        if leaving_preset and mode_bound is not None:
             _LOGGER.debug(
-                "Setting temperatures from no preset target mode. Old preset: %s, saved target temp: %s",
+                "Leaving preset %s, using %s bound: %s",
+                old_preset_mode,
+                hvac_mode,
+                mode_bound,
+            )
+            self.target_temp = mode_bound
+        elif leaving_preset and self.saved_target_temp is not None:
+            _LOGGER.debug(
+                "Leaving preset %s, no mode bound, using saved target temp: %s",
                 old_preset_mode,
                 self.saved_target_temp,
             )
             self.target_temp = self.saved_target_temp
         # switching from preset NONE to NONE
         elif supports_temp_range:
-            if (
-                hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY]
-                and self.target_temp_high is not None
-            ):
+            if mode_bound is not None:
                 _LOGGER.debug(
-                    "Setting temperatures from no preset target mode. HVACMode.COOL, target temp: %s",
-                    self.target_temp,
+                    "Setting temperatures from no preset target mode for %s: %s",
+                    hvac_mode,
+                    mode_bound,
                 )
-                self.target_temp = self.target_temp_high
-
-            elif hvac_mode == HVACMode.HEAT and self.target_temp_low is not None:
-                _LOGGER.debug(
-                    "Setting temperatures from no preset target mode. HVACMode.HEAT, target temp: %s",
-                    self.target_temp,
-                )
-                self.target_temp = self.target_temp_low
+                self.target_temp = mode_bound
         else:
             _LOGGER.debug(
                 "Setting temperatures from no preset target mode. Fallback to target_temp"

--- a/tests/managers/test_environment_manager.py
+++ b/tests/managers/test_environment_manager.py
@@ -3,6 +3,7 @@
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
+    PRESET_NONE,
     HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE
@@ -629,76 +630,86 @@ class TestIsWithinFanTolerance:
         assert env.is_within_fan_tolerance() is False
 
 
-class TestPresetReapplyAcrossHvacModes:
-    """Re-applying the active preset must not restore the other mode's setpoint.
+class TestSavedTargetTempIsNotModeScoped:
+    """`_saved_target_temp` must never override the current mode's own setpoint.
 
-    Regression tests for #641: in target mode the COOL/FAN_ONLY branch preferred
-    `_saved_target_temp` whenever the preset name was unchanged, without checking
-    that the saved value belonged to the current HVAC mode. A scheduler re-asserting
-    the preset it is already in therefore made a thermostat in COOL fall back to the
-    preset's HEAT setpoint.
+    Regression tests for #641. The saved value is written mode-agnostically (on
+    leaving PRESET_NONE, and on restart restore), so it can hold a setpoint
+    captured while the opposite HVAC mode was active. Two paths preferred it over
+    the mode's own bound, which made a thermostat in COOL target its HEAT
+    setpoint.
     """
 
-    def _apply(self, env, hvac_mode, preset_env, old_preset_mode):
+    RANGE_PRESET = {ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 24.0}
+
+    @pytest.mark.parametrize(
+        ("hvac_mode", "expected"),
+        [
+            (HVACMode.HEAT, 20.0),
+            (HVACMode.COOL, 24.0),
+            (HVACMode.FAN_ONLY, 24.0),
+        ],
+    )
+    async def test_reapplying_active_preset_uses_the_modes_own_bound(
+        self, environment_manager, hvac_mode, expected
+    ):
+        """A scheduler or UI re-asserting the preset already active (#641)."""
+        env = environment_manager
+        env.saved_target_temp = 99.0  # stale: captured under the other mode
+
         env.set_temepratures_from_hvac_mode_and_presets(
             hvac_mode=hvac_mode,
             supports_temp_range=True,
             preset_mode="comfort",
-            preset_env=preset_env,
+            preset_env=PresetEnv(**self.RANGE_PRESET),
             is_range_mode=False,
-            old_preset_mode=old_preset_mode,
+            old_preset_mode="comfort",  # the re-apply that regressed
         )
 
-    @pytest.mark.asyncio
-    async def test_reapplying_preset_in_cool_keeps_high_setpoint(
-        self, hass, basic_config
+        assert env.target_temp == expected
+
+    @pytest.mark.parametrize(
+        ("hvac_mode", "expected"),
+        [
+            (HVACMode.HEAT, 18.0),
+            (HVACMode.COOL, 26.0),
+            (HVACMode.FAN_ONLY, 26.0),
+        ],
+    )
+    async def test_leaving_a_preset_uses_the_modes_own_bound(
+        self, environment_manager, hvac_mode, expected
     ):
-        """heat -> cool, then re-assert the same preset: must stay on the high temp."""
-        env = EnvironmentManager(hass, basic_config)
-        preset_env = PresetEnv(
-            **{ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 24.0}
+        """Turning a preset off, e.g. heat -> preset -> cool -> preset off (#641)."""
+        env = environment_manager
+        env.target_temp_low = 18.0
+        env.target_temp_high = 26.0
+        env.saved_target_temp = 99.0  # stale: captured under the other mode
+
+        env.set_temepratures_from_hvac_mode_and_presets(
+            hvac_mode=hvac_mode,
+            supports_temp_range=True,
+            preset_mode=PRESET_NONE,
+            preset_env=None,
+            is_range_mode=False,
+            old_preset_mode="comfort",
         )
 
-        self._apply(env, HVACMode.HEAT, preset_env, old_preset_mode=None)
-        assert env.target_temp == 20.0
-        env._saved_target_temp = env.target_temp  # as the preset manager does
+        assert env.target_temp == expected
 
-        self._apply(env, HVACMode.COOL, preset_env, old_preset_mode=None)
-        assert env.target_temp == 24.0
-
-        # scheduler tick / UI resend of the preset already active
-        self._apply(env, HVACMode.COOL, preset_env, old_preset_mode="comfort")
-        assert (
-            env.target_temp == 24.0
-        ), "re-applying the preset restored the heat setpoint"
-
-    @pytest.mark.asyncio
-    async def test_reapplying_preset_in_heat_keeps_low_setpoint(
-        self, hass, basic_config
+    async def test_leaving_a_preset_still_falls_back_to_saved_temp(
+        self, environment_manager
     ):
-        """The mirrored direction, cool -> heat, must hold too."""
-        env = EnvironmentManager(hass, basic_config)
-        preset_env = PresetEnv(
-            **{ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 24.0}
+        """Without a mode bound to use, the saved temperature is still honoured."""
+        env = environment_manager
+        env.saved_target_temp = 21.0
+
+        env.set_temepratures_from_hvac_mode_and_presets(
+            hvac_mode=HVACMode.HEAT,
+            supports_temp_range=False,
+            preset_mode=PRESET_NONE,
+            preset_env=None,
+            is_range_mode=False,
+            old_preset_mode="comfort",
         )
 
-        self._apply(env, HVACMode.COOL, preset_env, old_preset_mode=None)
-        assert env.target_temp == 24.0
-        env._saved_target_temp = env.target_temp
-
-        self._apply(env, HVACMode.HEAT, preset_env, old_preset_mode="comfort")
-        assert env.target_temp == 20.0
-
-    @pytest.mark.asyncio
-    async def test_reapplying_preset_in_fan_only_keeps_high_setpoint(
-        self, hass, basic_config
-    ):
-        """FAN_ONLY shares the COOL branch."""
-        env = EnvironmentManager(hass, basic_config)
-        preset_env = PresetEnv(
-            **{ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 24.0}
-        )
-        env._saved_target_temp = 20.0
-
-        self._apply(env, HVACMode.FAN_ONLY, preset_env, old_preset_mode="comfort")
-        assert env.target_temp == 24.0
+        assert env.target_temp == 21.0

--- a/tests/managers/test_environment_manager.py
+++ b/tests/managers/test_environment_manager.py
@@ -627,3 +627,78 @@ class TestIsWithinFanTolerance:
         env._cur_temp = None
 
         assert env.is_within_fan_tolerance() is False
+
+
+class TestPresetReapplyAcrossHvacModes:
+    """Re-applying the active preset must not restore the other mode's setpoint.
+
+    Regression tests for #641: in target mode the COOL/FAN_ONLY branch preferred
+    `_saved_target_temp` whenever the preset name was unchanged, without checking
+    that the saved value belonged to the current HVAC mode. A scheduler re-asserting
+    the preset it is already in therefore made a thermostat in COOL fall back to the
+    preset's HEAT setpoint.
+    """
+
+    def _apply(self, env, hvac_mode, preset_env, old_preset_mode):
+        env.set_temepratures_from_hvac_mode_and_presets(
+            hvac_mode=hvac_mode,
+            supports_temp_range=True,
+            preset_mode="comfort",
+            preset_env=preset_env,
+            is_range_mode=False,
+            old_preset_mode=old_preset_mode,
+        )
+
+    @pytest.mark.asyncio
+    async def test_reapplying_preset_in_cool_keeps_high_setpoint(
+        self, hass, basic_config
+    ):
+        """heat -> cool, then re-assert the same preset: must stay on the high temp."""
+        env = EnvironmentManager(hass, basic_config)
+        preset_env = PresetEnv(
+            **{ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 24.0}
+        )
+
+        self._apply(env, HVACMode.HEAT, preset_env, old_preset_mode=None)
+        assert env.target_temp == 20.0
+        env._saved_target_temp = env.target_temp  # as the preset manager does
+
+        self._apply(env, HVACMode.COOL, preset_env, old_preset_mode=None)
+        assert env.target_temp == 24.0
+
+        # scheduler tick / UI resend of the preset already active
+        self._apply(env, HVACMode.COOL, preset_env, old_preset_mode="comfort")
+        assert (
+            env.target_temp == 24.0
+        ), "re-applying the preset restored the heat setpoint"
+
+    @pytest.mark.asyncio
+    async def test_reapplying_preset_in_heat_keeps_low_setpoint(
+        self, hass, basic_config
+    ):
+        """The mirrored direction, cool -> heat, must hold too."""
+        env = EnvironmentManager(hass, basic_config)
+        preset_env = PresetEnv(
+            **{ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 24.0}
+        )
+
+        self._apply(env, HVACMode.COOL, preset_env, old_preset_mode=None)
+        assert env.target_temp == 24.0
+        env._saved_target_temp = env.target_temp
+
+        self._apply(env, HVACMode.HEAT, preset_env, old_preset_mode="comfort")
+        assert env.target_temp == 20.0
+
+    @pytest.mark.asyncio
+    async def test_reapplying_preset_in_fan_only_keeps_high_setpoint(
+        self, hass, basic_config
+    ):
+        """FAN_ONLY shares the COOL branch."""
+        env = EnvironmentManager(hass, basic_config)
+        preset_env = PresetEnv(
+            **{ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 24.0}
+        )
+        env._saved_target_temp = 20.0
+
+        self._apply(env, HVACMode.FAN_ONLY, preset_env, old_preset_mode="comfort")
+        assert env.target_temp == 24.0


### PR DESCRIPTION
Fixes #641. Credit to @cb2206 — the report pinned the exact branch, both save sites, and the asymmetry with HEAT; this is essentially their option 3.

## The bug

In target mode, the COOL/FAN_ONLY branch of `_set_temps_when_have_preset_mode` preferred `_saved_target_temp` over the preset's own high value whenever the preset name hadn't changed:

```python
preset_match_old = old_preset_mode == preset_mode
self._target_temp = (
    self._saved_target_temp
    if preset_match_old and self._saved_target_temp
    else preset_temp_high
)
```

`_saved_target_temp` is **not mode-scoped**. It's written in mode-agnostic places — leaving `PRESET_NONE` (`preset_manager.py` ~L148) and restart restore (~L221) — so it can hold a setpoint captured while the *opposite* mode was active.

So anything that re-asserts the preset already active — a scheduler tick, a UI resend, `climate.set_preset_mode` with the current preset — made a thermostat in COOL fall back to the preset's **HEAT** setpoint and cool toward it. With `comfort: {target_temp_low: 20, target_temp_high: 24}`, an entity in `cool` ends up targeting 20 °C.

The HEAT branch immediately above already uses `preset_temp_low` unconditionally. That asymmetry is why the bug only presents after transitions *into* cool.

## The fix

Make COOL/FAN_ONLY match HEAT — always the preset's own value for the current mode.

**Restart restore is unaffected**, which was my main worry given this line came from #269. Two things make it safe:
- `climate.py` skips `set_temepratures_from_hvac_mode_and_presets` entirely when `is_restore` is set (both call sites, L1297 and L1772)
- `_apply_single_temp_mode_state` applies the persisted temperature *directly* (`self._environment.target_temp = float(old_temperature)`)

So the removed branch played no part in restart recovery.

## Tests

Three in `tests/managers/test_environment_manager.py`, following the reporter's repro:
- re-apply in COOL after heat→cool → must stay on the high setpoint
- re-apply in FAN_ONLY → same branch, same expectation
- the cool→heat direction, as a guard on the already-correct HEAT path

The first two fail against `master`; the third passes either way by design.

Full suite: **1544 passed, 2 skipped**. Lint clean.

## Note

`old_preset_mode` is now unused inside this method. I left the parameter in place — its sibling `_set_temps_when_no_preset_mode` still uses it and the callers pass it symmetrically — but happy to drop it if you'd rather.

@cb2206 — you offered to test with your 14 instances and the watchdog automation; that would be very welcome before this merges.

https://claude.ai/code/session_01R2RVM3N6RjLXT2qpEWNw3Y

---

## Update after review: a second affected path

The first commit fixed one of **two** places that preferred `_saved_target_temp` over the current mode's own setpoint. `_set_temps_when_target_mode` — the *leaving a preset* path — had the identical defect, checking the saved value **before** the branch that already computes the mode-correct one. Verified before touching it:

```
heat, target 20 -> preset(18/26) -> switch to cool -> target 26  (right)
                                 -> preset off     -> target 20  (wrong)
```

No scheduler needed — just heat → preset → cool → preset off — so it is arguably likelier to be hit than the re-apply case this issue was filed for. @cb2206, this may explain sightings your watchdog caught that the re-apply theory did not cover.

The mode's own bound now wins there too, with `saved_target_temp` kept as the fallback for when there is no bound to use (no range support, or a mode outside heat/cool/fan_only). Behaviour for every other combination is unchanged.

Both sites now resolve the setpoint through a single `_bound_for_mode` helper rather than parallel `if`/`elif` chains — which is what let the two paths drift apart to begin with. The collapse also removes a silent fall-through: HEAT with no low bound now logs the unhandled case like every other gap.

`preset_mode` and `old_preset_mode` were left unused in `_set_temps_when_have_preset_mode` once `preset_match_old` went — they were its only consumers — so they are dropped from that private signature. The public entry point still takes `old_preset_mode`; the `PRESET_NONE` path uses it.

Tests are now parametrized over the three modes instead of near-copies, use the existing `environment_manager` fixture and the public `saved_target_temp` setter (the same door `preset_manager` writes through), and stage the stale value as `99.0` — neither bound — so a regression fails loudly rather than landing on a plausible number.

**1548 passed, 2 skipped.** Three of the seven new cases fail against `master`.

## Still not addressed

`_saved_target_temp` remains an un-scoped duplicate of state that `target_temp_low`/`target_temp_high` already track per mode, and it has a third read at the "preset defines no temperatures" branch with the same latent staleness. Removing it in favour of the low/high pair would touch restart restore and the `ATTR_PREV_TARGET` attribute, so it belongs in its own change rather than here.
